### PR TITLE
Fix: Resize Handler Console Error Fix (fixes #10)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,6 +10,7 @@
 - Avinash Gupta [@avinashg1994]
 - Ben Cai [@benbcai]
 - Matt Henkes [@mjhenkes]
+- Janani Gunasekaran [@JananiGunasekaran]
 
 [@abhijit945]: https://github.com/abhijit945
 [@dinesh94singh]: https://github.com/Dinesh94Singh
@@ -21,3 +22,4 @@
 [@avinashg1994]: https://github.com/avinashg1994
 [@benbcai]: https://github.com/benbcai
 [@mjhenkes]: https://github.com/mjhenkes
+[@JananiGunasekaran]: https://github.com/JananiGunasekaran

--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -1,8 +1,8 @@
 # ChangeLog
-
-* Changed
-  * Added a condition to check if graphContainer is present and then resize the graph.
   
 ## Unreleased
 
 -   Migrated to the terra-graphs mono-rep.
+
+* Changed
+  * Added a condition to check if graphContainer is present and then resize the graph.

--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+* Changed
+  * Added a condition to check if graphContainer is present and then resize the graph.
+  
 ## Unreleased
 
 -   Migrated to the terra-graphs mono-rep.

--- a/packages/carbon-graphs/src/js/controls/Graph/Graph.js
+++ b/packages/carbon-graphs/src/js/controls/Graph/Graph.js
@@ -317,10 +317,13 @@ class Graph extends Construct {
      *  @returns {Graph} - Graph instance
      */
   resize() {
-    setCanvasWidth(this.graphContainer, this.config);
-    scaleGraph(this.scale, this.config);
-    translateGraph(this);
-    this.content.forEach((control) => control.resize(this));
+    // Check if graphContainer is present and then resize the graph
+    if (this.graphContainer) {
+      setCanvasWidth(this.graphContainer, this.config);
+      scaleGraph(this.scale, this.config);
+      translateGraph(this);
+      this.content.forEach((control) => control.resize(this));
+    }
     return this;
   }
 

--- a/packages/carbon-graphs/tests/unit/controls/Graph/GraphResize-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Graph/GraphResize-spec.js
@@ -586,8 +586,8 @@ describe('Graph - Resize', () => {
       expect(graph.config.canvasHeight).toBe(250);
     });
   });
-  describe("Only when graph container is present", () => {
-    it("Resize the graph", (done) => {
+  describe("When the graph container is present", () => {
+    it("Should resize the graph", (done) => {
       expect(graph.config.canvasWidth).toBe(1024);
       const canvasElement = fetchElementByClass(styles.canvas);
       graphContainer.setAttribute("style", "width: 800px; height: 200px");

--- a/packages/carbon-graphs/tests/unit/controls/Graph/GraphResize-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Graph/GraphResize-spec.js
@@ -586,4 +586,27 @@ describe('Graph - Resize', () => {
       expect(graph.config.canvasHeight).toBe(250);
     });
   });
+  describe("Only when graph container is present", () => {
+    it("Resize the graph", (done) => {
+      expect(graph.config.canvasWidth).toBe(1024);
+      const canvasElement = fetchElementByClass(styles.canvas);
+      graphContainer.setAttribute("style", "width: 800px; height: 200px");
+      graph.resize();
+      triggerEvent(window, "resize", () => {
+        expect(graph.config.canvasWidth).toBe(800);
+        expect(graph.scale.x).not.toBeNull();
+        expect(graph.scale.x).toEqual(jasmine.any(Function));
+        expect(graph.scale.y).not.toBeNull();
+        expect(graph.scale.y).toEqual(jasmine.any(Function));
+        expect(toNumber(canvasElement.getAttribute("height"))).not.toBe(
+          0
+        );
+        expect(
+          toNumber(canvasElement.getAttribute("height"))
+        ).toBeGreaterThan(0);
+        expect(toNumber(canvasElement.getAttribute("width"))).toBe(790);
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
Using resizeHandler in advanced graphing application throws a console error. 
![image](https://user-images.githubusercontent.com/60426528/99498376-5e157180-299d-11eb-9939-17b3868855b8.png)
To fix the error, we have to add a condition to check if the graphContainer is present and then resize the graph.

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #10 

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-graphs-deployed-pr-45.herokuapp.com/ -->
https://terra-graphs-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->
Unit test

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->
<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
@cerner/carbon
