### PR TITLE
Fix: Reflow does not accept Paired Result with low/high/mid value as undefined/null/blank

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@
 - Ben Cai [@benbcai]
 - Matt Henkes [@mjhenkes]
 - Janani Gunasekaran [@JananiGunasekaran]
+- Ashish Motanam Gurunadham[@ashishmotanamgurunadham]
 
 [@abhijit945]: https://github.com/abhijit945
 [@dinesh94singh]: https://github.com/Dinesh94Singh
@@ -23,3 +24,4 @@
 [@benbcai]: https://github.com/benbcai
 [@mjhenkes]: https://github.com/mjhenkes
 [@JananiGunasekaran]: https://github.com/JananiGunasekaran
+[@ashishmotanamgurunadham]: https://github.com/AshishMotanamGurunadham

--- a/package.json
+++ b/package.json
@@ -33,6 +33,12 @@
   "dependencies": {
     "d3": "^5.16.0"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm run lint",
+      "pre-push": "npm run test"
+    }
+  },
   "devDependencies": {
     "@babel/cli": "^7.5.0",
     "@babel/core": "^7.5.0",

--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Changed
   * For consistency updated reflow in Graph and Gantt constructs to update the eventlines.
+  * Added code to handle null/undefined/blank in paired result graph during both initial load and reflow.
 
 ## 2.15.0 - (November 24, 2020)
 

--- a/packages/carbon-graphs/src/js/controls/PairedResult/PairedResult.js
+++ b/packages/carbon-graphs/src/js/controls/PairedResult/PairedResult.js
@@ -94,7 +94,7 @@ const filterPairedResultData = (data) => {
         filteredValue[t] = value[t];
       }
     });
-    filteredData.push(temp);
+    filteredData.push(filteredValue);
   });
   return filteredData;
 }

--- a/packages/carbon-graphs/src/js/controls/PairedResult/PairedResult.js
+++ b/packages/carbon-graphs/src/js/controls/PairedResult/PairedResult.js
@@ -86,17 +86,15 @@ const loadInput = (inputJSON) => new PairedResultConfig()
  * @returns {object} filteredData - filtered data object
  */
 const filterPairedResultData = (data) => {
-  let filteredData = [];
   data.map((value) => {
     let filteredValue = {};
     iterateOnPairType((t) => {
-      if(value[t] != null && !(typeof value[t] === 'object' && Object.keys(value[t]).length === 0)){
-        filteredValue[t] = value[t];
+      if(!(value[t] != null && !(typeof value[t] === 'object' && Object.keys(value[t]).length === 0))){
+        delete value[t];
       }
     });
-    filteredData.push(filteredValue);
   });
-  return filteredData;
+  return data;
 }
 /**
  * A Paired result graph is a graph that is represented by 2 points

--- a/packages/carbon-graphs/src/js/controls/PairedResult/PairedResult.js
+++ b/packages/carbon-graphs/src/js/controls/PairedResult/PairedResult.js
@@ -79,6 +79,27 @@ const loadInput = (inputJSON) => new PairedResultConfig()
   .getConfig();
 
 /**
+ * Filters invalid data like null and blank.
+ *
+ * @private
+ * @param {object} data - Data points object
+ * @returns {object} filteredData - filtered data object
+ */
+const filterPairedResultData = (data) => {
+  let filteredData = [];
+  data.map((value) => {
+    let temp = {};
+    iterateOnPairType((t) => {
+
+      if(value[t] != null && !(typeof value[t] === 'object' && Object.keys(value[t]).length === 0)){
+        temp[t] = value[t];
+      }
+    });
+    filteredData.push(temp);
+  });
+  return filteredData;
+}
+/**
  * A Paired result graph is a graph that is represented by 2 points
  * and a line connecting them. There may be an optional 3rd datapoint
  * representing a median between them.
@@ -128,6 +149,7 @@ class PairedResult extends GraphContent {
       this.config.yAxis,
       constants.Y_AXIS,
     );
+    this.config.values  = filterPairedResultData(this.config.values);
     this.valuesRange = calculateValuesRange(
       this.config.values,
       this.config.yAxis,
@@ -273,7 +295,8 @@ class PairedResult extends GraphContent {
       type,
     });
     const reflow = !!this.config.values.length;
-    this.config.values = graphData.values;
+    this.config.values = utils.deepClone(graphData.values);
+    this.config.values = filterPairedResultData(this.config.values);
     this.dataTarget = processDataPoints(graph.config, this.config, reflow);
     const drawBox = (boxPath) => {
       drawSelectionIndicator(graph.scale, graph.config, boxPath);

--- a/packages/carbon-graphs/src/js/controls/PairedResult/PairedResult.js
+++ b/packages/carbon-graphs/src/js/controls/PairedResult/PairedResult.js
@@ -86,15 +86,15 @@ const loadInput = (inputJSON) => new PairedResultConfig()
  * @returns {object} filteredData - filtered data object
  */
 const filterPairedResultData = (data) => {
-  data.map((value) => {
+  return data.map((value) => {
     let filteredValue = {};
     iterateOnPairType((t) => {
-      if(!(value[t] != null && !(typeof value[t] === 'object' && Object.keys(value[t]).length === 0))){
-        delete value[t];
+      if(value[t] != null && !(typeof value[t] === 'object' && Object.keys(value[t]).length === 0)){
+        filteredValue[t] = value[t];
       }
     });
+    return filteredValue;
   });
-  return data;
 }
 /**
  * A Paired result graph is a graph that is represented by 2 points

--- a/packages/carbon-graphs/src/js/controls/PairedResult/PairedResult.js
+++ b/packages/carbon-graphs/src/js/controls/PairedResult/PairedResult.js
@@ -88,11 +88,10 @@ const loadInput = (inputJSON) => new PairedResultConfig()
 const filterPairedResultData = (data) => {
   let filteredData = [];
   data.map((value) => {
-    let temp = {};
+    let filteredValue = {};
     iterateOnPairType((t) => {
-
       if(value[t] != null && !(typeof value[t] === 'object' && Object.keys(value[t]).length === 0)){
-        temp[t] = value[t];
+        filteredValue[t] = value[t];
       }
     });
     filteredData.push(temp);

--- a/packages/carbon-graphs/tests/unit/controls/PairedResult/PairedResultLoad-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/PairedResult/PairedResultLoad-spec.js
@@ -367,6 +367,286 @@ describe('Paired Result - Load', () => {
       );
       expect(point.length).toBe(0);
     });
+    describe('when invalid data is passed', () => {
+      describe('for paired result high,', () => {
+        it('should remove datapoint when undefined is passed', () => {
+          graphDefault.destroy();
+          graphDefault = new Graph(getAxes(axisDefault));
+          input = getInput(
+            [
+              {
+                high: undefined,
+                mid: {
+                  x: 45,
+                  y: 146,
+                },
+                low: {
+                  x: 20,
+                  y: 120,
+                },
+              },
+            ],
+            false,
+            false,
+          );
+          graphDefault.loadContent(new PairedResult(input));
+          const pair = fetchElementByClass(
+            pairedResultGraphContainer,
+            styles.pairedBox,
+          );
+          const pointGroup = pair.querySelectorAll(
+              `.${styles.pointGroup}`,
+          );
+          expect(pointGroup.length).toEqual(2);
+        });
+        it('should remove datapoint when null is passed', () => {
+          graphDefault.destroy();
+          graphDefault = new Graph(getAxes(axisDefault));
+          input = getInput(
+            [
+              {
+                high: null,
+                mid: {
+                  x: 45,
+                  y: 146,
+                },
+                low: {
+                  x: 20,
+                  y: 120,
+                },
+              },
+            ],
+            false,
+            false,
+          );
+          graphDefault.loadContent(new PairedResult(input));
+          const pair = fetchElementByClass(
+            pairedResultGraphContainer,
+            styles.pairedBox,
+          );
+          const pointGroup = pair.querySelectorAll(
+              `.${styles.pointGroup}`,
+          );
+          expect(pointGroup.length).toEqual(2);
+        });
+        it('should remove datapoint when blank is passed', () => {
+          graphDefault.destroy();
+          graphDefault = new Graph(getAxes(axisDefault));
+          input = getInput(
+            [
+              {
+                high: {
+
+                },
+                mid: {
+                  x: 45,
+                  y: 146,
+                },
+                low: {
+                  x: 20,
+                  y: 120,
+                },
+              },
+            ],
+            false,
+            false,
+          );
+          graphDefault.loadContent(new PairedResult(input));
+          const pair = fetchElementByClass(
+            pairedResultGraphContainer,
+            styles.pairedBox,
+          );
+          const pointGroup = pair.querySelectorAll(
+              `.${styles.pointGroup}`,
+          );
+          expect(pointGroup.length).toEqual(2);
+        });
+      });
+      describe('for paired result mid,', () => {
+        it('should remove datapoint when undefined is passed', () => {
+          graphDefault.destroy();
+          graphDefault = new Graph(getAxes(axisDefault));
+          input = getInput(
+            [
+              {
+                high: {
+                  x: 45,
+                  y: 146,
+                },
+                mid: undefined,
+                low: {
+                  x: 20,
+                  y: 120,
+                },
+              },
+            ],
+            false,
+            false,
+          );
+          graphDefault.loadContent(new PairedResult(input));
+          const pair = fetchElementByClass(
+            pairedResultGraphContainer,
+            styles.pairedBox,
+          );
+          const pointGroup = pair.querySelectorAll(
+              `.${styles.pointGroup}`,
+          );
+          expect(pointGroup.length).toEqual(2);
+        });
+        it('should remove datapoint when null is passed', () => {
+          graphDefault.destroy();
+          graphDefault = new Graph(getAxes(axisDefault));
+          input = getInput(
+            [
+              {
+                high: {
+                  x: 45,
+                  y: 146,
+                },
+                mid: null,
+                low: {
+                  x: 20,
+                  y: 120,
+                },
+              },
+            ],
+            false,
+            false,
+          );
+          graphDefault.loadContent(new PairedResult(input));
+          const pair = fetchElementByClass(
+            pairedResultGraphContainer,
+            styles.pairedBox,
+          );
+          const pointGroup = pair.querySelectorAll(
+              `.${styles.pointGroup}`,
+          );
+          expect(pointGroup.length).toEqual(2);
+        });
+        it('should remove datapoint when blank is passed', () => {
+          graphDefault.destroy();
+          graphDefault = new Graph(getAxes(axisDefault));
+          input = getInput(
+            [
+              {
+                high: {
+                  x: 45,
+                  y: 146,
+                },
+                mid: {},
+                low: {
+                  x: 20,
+                  y: 120,
+                },
+              },
+            ],
+            false,
+            false,
+          );
+          graphDefault.loadContent(new PairedResult(input));
+          const pair = fetchElementByClass(
+            pairedResultGraphContainer,
+            styles.pairedBox,
+          );
+          const pointGroup = pair.querySelectorAll(
+              `.${styles.pointGroup}`,
+          );
+          expect(pointGroup.length).toEqual(2);
+        });
+      });
+      describe('for paired result low,', () => {
+        it('should remove datapoint when undefined is passed', () => {
+          graphDefault.destroy();
+          graphDefault = new Graph(getAxes(axisDefault));
+          input = getInput(
+            [
+              {
+                high: {
+                  x: 45,
+                  y: 146,
+                },
+                mid: {
+                  x: 20,
+                  y: 120,
+                },
+                low: undefined,
+              },
+            ],
+            false,
+            false,
+          );
+          graphDefault.loadContent(new PairedResult(input));
+          const pair = fetchElementByClass(
+            pairedResultGraphContainer,
+            styles.pairedBox,
+          );
+          const pointGroup = pair.querySelectorAll(
+              `.${styles.pointGroup}`,
+          );
+          expect(pointGroup.length).toEqual(2);
+        });
+        it('should remove datapoint when null is passed', () => {
+          graphDefault.destroy();
+          graphDefault = new Graph(getAxes(axisDefault));
+          input = getInput(
+            [
+              {
+                high: {
+                  x: 45,
+                  y: 146,
+                },
+                mid: {
+                  x: 20,
+                  y: 120,
+                },
+                low: null,
+              },
+            ],
+            false,
+            false,
+          );
+          graphDefault.loadContent(new PairedResult(input));
+          const pair = fetchElementByClass(
+            pairedResultGraphContainer,
+            styles.pairedBox,
+          );
+          const pointGroup = pair.querySelectorAll(
+              `.${styles.pointGroup}`,
+          );
+          expect(pointGroup.length).toEqual(2);
+        });
+        it('should remove datapoint when blank is passed', () => {
+          graphDefault.destroy();
+          graphDefault = new Graph(getAxes(axisDefault));
+          input = getInput(
+            [
+              {
+                high: {
+                  x: 45,
+                  y: 146,
+                },
+                mid: {
+                  x: 20,
+                  y: 120,
+                },
+                low: {},
+              },
+            ],
+            false,
+            false,
+          );
+          graphDefault.loadContent(new PairedResult(input));
+          const pair = fetchElementByClass(
+            pairedResultGraphContainer,
+            styles.pairedBox,
+          );
+          const pointGroup = pair.querySelectorAll(
+              `.${styles.pointGroup}`,
+          );
+          expect(pointGroup.length).toEqual(2);
+        });
+      });
+    });
     describe('data points have correct unique key', () => {
       it('line', () => {
         const lineElement = fetchElementByClass(

--- a/packages/carbon-graphs/tests/unit/controls/PairedResult/PairedResultPanning-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/PairedResult/PairedResultPanning-spec.js
@@ -213,6 +213,258 @@ describe('PairedResult', () => {
       );
       expect(pairedContent.length).toEqual(2);
     });
+    describe('when invalid data is passed', () => {
+      describe('for paired result high,', () => {
+        it('should remove datapoint when undefined is passed', () => {
+          const panData = {
+            key: 'uid_1',
+            values: [
+              {
+                high: undefined,
+                mid: {
+                  x: '2016-09-18T12:00:00Z',
+                  y: 70,
+                },
+                low: {
+                  x: '2016-09-19T02:00:00Z',
+                  y: 30,
+                },
+              },
+            ],
+          };
+          graphDefault.reflow(panData);
+          const pair = fetchElementByClass(
+            pairedResultGraphContainer,
+            styles.pairedBox,
+          );
+          const pointGroup = pair.querySelectorAll(
+              `.${styles.pointGroup}`,
+          );
+          expect(pointGroup.length).toEqual(2);
+        });
+        it('should remove datapoint when null is passed ', () => {
+          const panData = {
+            key: 'uid_1',
+            values: [
+              {
+                high: null,
+                mid: {
+                  x: '2016-09-18T12:00:00Z',
+                  y: 70,
+                },
+                low: {
+                  x: '2016-09-19T02:00:00Z',
+                  y: 30,
+                },
+              },
+            ],
+          };
+          graphDefault.reflow(panData);
+          const pair = fetchElementByClass(
+            pairedResultGraphContainer,
+            styles.pairedBox,
+          );
+          const pointGroup = pair.querySelectorAll(
+              `.${styles.pointGroup}`,
+          );
+          expect(pointGroup.length).toEqual(2);
+        });
+        it('should remove datapoint when blank is passed ', () => {
+          const panData = {
+            key: 'uid_1',
+            values: [
+              {
+                high: {
+                },
+                mid: {
+                  x: '2016-09-18T12:00:00Z',
+                  y: 70,
+                },
+                low: {
+                  x: '2016-09-19T02:00:00Z',
+                  y: 30,
+                },
+              },
+            ],
+          };
+          graphDefault.reflow(panData);
+          const pair = fetchElementByClass(
+            pairedResultGraphContainer,
+            styles.pairedBox,
+          );
+          const pointGroup = pair.querySelectorAll(
+              `.${styles.pointGroup}`,
+          );
+          expect(pointGroup.length).toEqual(2);
+        });
+      });
+      describe('for paired result mid', () => {
+        it('should remove datapoint when undefined is passed', () => {
+          const panData = {
+            key: 'uid_1',
+            values: [
+              {
+                high: {
+                  x: '2016-09-18T12:00:00Z',
+                  y: 70,
+                },
+                mid: undefined,
+                low: {
+                  x: '2016-09-19T02:00:00Z',
+                  y: 30,
+                },
+              },
+            ],
+          };
+          graphDefault.reflow(panData);
+          const pair = fetchElementByClass(
+            pairedResultGraphContainer,
+            styles.pairedBox,
+          );
+          const pointGroup = pair.querySelectorAll(
+              `.${styles.pointGroup}`,
+          );
+          expect(pointGroup.length).toEqual(2);
+        });
+        it('should remove datapoint when null is passed ', () => {
+          const panData = {
+            key: 'uid_1',
+            values: [
+              {
+                high: {
+                  x: '2016-09-18T12:00:00Z',
+                  y: 70,
+                },
+                mid: null,
+                low: {
+                  x: '2016-09-19T02:00:00Z',
+                  y: 30,
+                },
+              },
+            ],
+          };
+          graphDefault.reflow(panData);
+          const pair = fetchElementByClass(
+            pairedResultGraphContainer,
+            styles.pairedBox,
+          );
+          const pointGroup = pair.querySelectorAll(
+              `.${styles.pointGroup}`,
+          );
+          expect(pointGroup.length).toEqual(2);
+        });
+        it('should remove datapoint when blank is passed ', () => {
+          const panData = {
+            key: 'uid_1',
+            values: [
+              {
+                high: {
+                  x: '2016-09-18T12:00:00Z',
+                  y: 70,
+                },
+                mid: { },
+                low: {
+                  x: '2016-09-19T02:00:00Z',
+                  y: 30,
+                },
+              },
+            ],
+          };
+          graphDefault.reflow(panData);
+          const pair = fetchElementByClass(
+            pairedResultGraphContainer,
+            styles.pairedBox,
+          );
+          const pointGroup = pair.querySelectorAll(
+              `.${styles.pointGroup}`,
+          );
+          expect(pointGroup.length).toEqual(2);
+        });
+      });
+      describe('for paired result low', () => {
+        it('should remove datapoint when undefined is passed', () => {
+          const panData = {
+            key: 'uid_1',
+            values: [
+              {
+                high: {
+                  x: '2016-09-18T12:00:00Z',
+                  y: 70,
+                },
+                mid: {
+                  x: '2016-09-19T02:00:00Z',
+                  y: 30,
+                },
+                low: undefined,
+              },
+            ],
+          };
+          graphDefault.reflow(panData);
+          const pair = fetchElementByClass(
+            pairedResultGraphContainer,
+            styles.pairedBox,
+          );
+          const pointGroup = pair.querySelectorAll(
+              `.${styles.pointGroup}`,
+          );
+          expect(pointGroup.length).toEqual(2);
+        });
+        it('should remove datapoint when null is passed ', () => {
+          const panData = {
+            key: 'uid_1',
+            values: [
+              {
+                high: {
+                  x: '2016-09-18T12:00:00Z',
+                  y: 70,
+                },
+                mid: {
+                  x: '2016-09-19T02:00:00Z',
+                  y: 30,
+                },
+                low: null,
+              },
+            ],
+          };
+          graphDefault.reflow(panData);
+          const pair = fetchElementByClass(
+            pairedResultGraphContainer,
+            styles.pairedBox,
+          );
+          const pointGroup = pair.querySelectorAll(
+              `.${styles.pointGroup}`,
+          );
+          expect(pointGroup.length).toEqual(2);
+        });
+        it('should remove datapoint when blank is passed ', () => {
+          const panData = {
+            key: 'uid_1',
+            values: [
+              {
+                high: {
+                  x: '2016-09-18T12:00:00Z',
+                  y: 70,
+                },
+                mid: {
+                  x: '2016-09-19T02:00:00Z',
+                  y: 30,
+                },
+                low: { },
+              },
+            ],
+          };
+          graphDefault.reflow(panData);
+          const pair = fetchElementByClass(
+            pairedResultGraphContainer,
+            styles.pairedBox,
+          );
+          const pointGroup = pair.querySelectorAll(
+              `.${styles.pointGroup}`,
+          );
+          expect(pointGroup.length).toEqual(2);
+        });
+      });
+    });
     describe('when there is no data', () => {
       it('should update the dynamic data and disable the legend', () => {
         const panData = {

--- a/packages/terra-graphs/docs/contributing/README.md
+++ b/packages/terra-graphs/docs/contributing/README.md
@@ -135,9 +135,6 @@ For any breaking changes, add information on how to migrate from previous versio
 Create an issue and add any stakeholders to that issue.
 This issue will be closed once you have :+1: from all of the stakeholders (or subsequent issues are created within their own git repo queues).
 
-####Note: 
+#### Note: 
 
-To run WDIO test cases in local, you must install docker on your machine.
-
-Install Docker version 17.09.0 or higher. Installation instructions can be found at https://docs.docker.com/install/.
-
+To run the WDIO tests locally, please install docker version 17.09.0 or higher. Installation instructions can found [here](https://docs.docker.com/get-docker/).

--- a/packages/terra-graphs/docs/contributing/README.md
+++ b/packages/terra-graphs/docs/contributing/README.md
@@ -134,3 +134,10 @@ Deployment of site is automated, and will be performed when PR is merged to `mai
 For any breaking changes, add information on how to migrate from previous version along with changes that was provided.
 Create an issue and add any stakeholders to that issue.
 This issue will be closed once you have :+1: from all of the stakeholders (or subsequent issues are created within their own git repo queues).
+
+####Note: 
+
+To run WDIO test cases in local, you must install docker on your machine.
+
+Install Docker version 17.09.0 or higher. Installation instructions can be found at https://docs.docker.com/install/.
+

--- a/packages/terra-graphs/docs/controls/PairedResult.md
+++ b/packages/terra-graphs/docs/controls/PairedResult.md
@@ -150,21 +150,15 @@ Each paired result can have a style object in [Values](#values) level.
 
 ### Values
 
-#### Required
-
 | Property Name | Expected | Value                                            | Description                                               |
 | ------------- | -------- | ------------------------------------------------ | --------------------------------------------------------- |
 | high          | object   | _{x: "", y: "", isCritical: `true`, region: {}}_ | Data point co-ordinate x and y, Refer [Regions](#regions) |
 | low           | object   | _{x: "", y: "", isCritical: `true`, region: {}}_ | Data point co-ordinate x and y, Refer [Regions](#regions) |
-
-#### Optional
-
-| Property Name | Expected | Value                                            | Description                                               |
-| ------------- | -------- | ------------------------------------------------ | --------------------------------------------------------- |
 | mid           | object   | _{x: "", y: "", isCritical: `true`, region: {}}_ | Data point co-ordinate x and y, Refer [Regions](#regions) |
 
 `Note:`
 
+- At least one of the high/low/medium should be provided with valid data.
 -   `isCritical` toggle is disabled by default
 -   When `isCritical` toggle is enabled, an indicator will be shown surrounding the data point
 
@@ -177,17 +171,10 @@ Draws a Horizontal area along the X-Axis
 -   Each pair type mentioned above needs to have a `start` and `end`,
 -   If at least one region is defined for a value in the element, it will take precedence over the element's region and the element's region will not be displayed.
 
-#### Required
-
 | Property Name | Expected | Value                              | Description                   |
 | ------------- | -------- | ---------------------------------- | ----------------------------- |
 | high          | object   | _{start: `number`, end: `number`}_ | Start and end `@type: number` |
 | low           | object   | _{start: `number`, end: `number`}_ | Start and end `@type: number` |
-
-#### Optional
-
-| Property Name | Expected | Value                              | Description                   |
-| ------------- | -------- | ---------------------------------- | ----------------------------- |
 | mid           | object   | _{start: `number`, end: `number`}_ | Start and end `@type: number` |
 
 #### Optional type properties


### PR DESCRIPTION
### Summary
- With these changes paired result is now capable of handling null/blank/undefined during both initial load and reflow(by getting rid of those points passed by consumers).

Closes #11 

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-graphs-deployed-pr-45.herokuapp.com/ -->
https://terra-graphs-deployed-pr-#.herokuapp.com/

### Testing
- In this issue, each case like high/low/medium as undefined/null/blank has been tested.

### Additional Details


**Handling undefined during reflow:** 

**Before:**

- When undefined is passed as high during reflow we can see an error as shown in the image below.

![image](https://user-images.githubusercontent.com/63670637/99457288-58ae1d80-28f0-11eb-81b1-20db807704ec.png)

**After:**

-  Due to changes made in this issue error got resolved.

**Handling null/blank during reflow:** 

- Previously, terra-graphs only handles undefined values as high/low/mid. Because of current changes terra-graphs now can handle null/blank values too as high/mid/low during both initial load and reflow by getting rid of those invalid values. 


<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
@cerner/carbon
