### PR TITLE
Handling invalid data when passed to y.

### DIFF
--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -4,13 +4,12 @@
 
 * Changed
   * For consistency replaced `document` in all draw helpers with `graph.legendSVG` for better control.
-
-* Changed
   * For consistency updated reflow in Graph and Gantt constructs to update the eventlines.
   * Added code to handle null/undefined/blank in paired result graph during both initial load and reflow.
   * Updated `packages/carbon-graphs/README.md` so that it has more essential information about Carbon.
   * Added array handling for loadContent on Construct based graphs.
-
+  * Throw an error when null/undefined/blank is passed as y value.
+  
 ## 2.15.0 - (November 24, 2020)
 
 * Changed

--- a/packages/carbon-graphs/karma.config.js
+++ b/packages/carbon-graphs/karma.config.js
@@ -29,7 +29,7 @@ module.exports = function (config) {
     },
     singleRun: true,
     files: [
-      './node_modules/@babel/polyfill/dist/polyfill.js',
+      './../../node_modules/@babel/polyfill/dist/polyfill.js',
       './webpack/tests.webpack.js',
     ],
     frameworks: ['parallel', 'jasmine'],

--- a/packages/carbon-graphs/src/js/controls/Bar/Bar.js
+++ b/packages/carbon-graphs/src/js/controls/Bar/Bar.js
@@ -10,6 +10,7 @@ import {
 import { removeLegendItem, reflowLegend } from '../../helpers/legend';
 import styles from '../../helpers/styles';
 import utils from '../../helpers/utils';
+import { validateData } from '../../helpers/constructUtils';
 import BarConfig from './BarConfig';
 import { removeAxisInfoRowLabels } from './helpers/axisInfoRowHelpers';
 import {
@@ -117,6 +118,7 @@ class Bar extends GraphContent {
      * @inheritdoc
      */
   load(graph) {
+    validateData(this.config.values);
     setGroupName(this.config, graph.content);
     scaleBandAxis(this.bandScale, graph.config, graph.content);
     this.dataTarget = processDataPoints(graph.config, this.config);
@@ -231,6 +233,7 @@ class Bar extends GraphContent {
       hoverHandler: hoverHandler(graph.config.shownTargets, graph.svg),
     };
     this.config.values = graphData.values;
+    validateData(this.config.values);
     this.dataTarget = processDataPoints(graph.config, this.config);
     const position = graph.config.shownTargets.lastIndexOf(graphData.key);
     if (position > -1) {

--- a/packages/carbon-graphs/src/js/controls/Bubble/BubbleMultipleDataset.js
+++ b/packages/carbon-graphs/src/js/controls/Bubble/BubbleMultipleDataset.js
@@ -16,6 +16,7 @@ import {
 } from './helpers/helpers';
 import { draw, drawBubbles } from './helpers/helpersMultipleDataset';
 import Bubble from './Bubble';
+import {validateData} from "../../helpers/constructUtils";
 
 /**
  * A Bubble graph is a graph used to represent a collection of data
@@ -43,7 +44,7 @@ class BubbleMultipleDataset extends Bubble {
       );
       return this;
     }
-
+    validateData(this.config.values);
     this.dataTarget = processDataPoints(graph.config, this.config);
     draw(graph.scale, graph.config, graph.svg, this.dataTarget);
     if (utils.notEmpty(this.dataTarget.regions)) {
@@ -99,6 +100,7 @@ class BubbleMultipleDataset extends Bubble {
       hoverHandler: hoverHandler(graph.config.shownTargets, graph.svg),
     };
     this.config.values = graphData.values;
+    validateData(this.config.values);
     this.dataTarget = processDataPoints(graph.config, this.config);
     const position = graph.config.shownTargets.lastIndexOf(graphData.key);
 

--- a/packages/carbon-graphs/src/js/controls/Bubble/BubbleSingleDataset.js
+++ b/packages/carbon-graphs/src/js/controls/Bubble/BubbleSingleDataset.js
@@ -22,6 +22,7 @@ import {
 } from './helpers/helpers';
 import { draw, drawBubbles } from './helpers/helpersSingleDataset';
 import Bubble from './Bubble';
+import {validateData} from "../../helpers/constructUtils";
 
 /**
  * A Bubble graph is a graph used to represent a collection of data
@@ -47,7 +48,6 @@ class BubbleSingleDataset extends Bubble {
       console.warn('BubbleSingleDataset can only use one dataset.');
       return this;
     }
-
     if (
       utils.isUndefined(graph.content[0].config.color)
             && utils.isDefined(graph.content[0].config.palette)
@@ -58,7 +58,7 @@ class BubbleSingleDataset extends Bubble {
       console.warn('Cannot plot more than 4 bubbles using shades.');
       return this;
     }
-
+    validateData(this.config.values);
     this.dataTarget = processDataPoints(graph.config, this.config);
     draw(graph.scale, graph.config, graph.svg, this.dataTarget);
 
@@ -129,6 +129,7 @@ class BubbleSingleDataset extends Bubble {
       hoverHandler: hoverHandler(graph.config.shownTargets, graph.svg),
     };
     this.config.values = graphData.values;
+    validateData(this.config.values);
     this.dataTarget = processDataPoints(graph.config, this.config);
     const position = graph.config.shownTargets.lastIndexOf(graphData.key);
 

--- a/packages/carbon-graphs/src/js/controls/Bubble/helpers/helpersMultipleDataset.js
+++ b/packages/carbon-graphs/src/js/controls/Bubble/helpers/helpersMultipleDataset.js
@@ -141,7 +141,7 @@ const draw = (scale, config, canvasSVG, dataTarget) => {
 
   const bubblePoint = BubbleSVG.select(`.${styles.currentPointsGroup}`)
     .selectAll(`.${styles.point}`)
-    .data(getDataPointValues(dataTarget).filter((d) => d.y !== null));
+    .data(getDataPointValues(dataTarget));
   drawBubbles(scale, config, bubblePoint.enter(), dataTarget);
   bubblePoint
     .exit()

--- a/packages/carbon-graphs/src/js/controls/Bubble/helpers/helpersSingleDataset.js
+++ b/packages/carbon-graphs/src/js/controls/Bubble/helpers/helpersSingleDataset.js
@@ -164,7 +164,7 @@ const draw = (scale, config, canvasSVG, dataTarget) => {
 
   const bubblePoint = BubbleSVG.select(`.${styles.currentPointsGroup}`)
     .selectAll(`.${styles.point}`)
-    .data(getDataPointValues(dataTarget).filter((d) => d.y !== null));
+    .data(getDataPointValues(dataTarget));
   drawBubbles(scale, config, bubblePoint.enter(), dataTarget);
   bubblePoint
     .exit()

--- a/packages/carbon-graphs/src/js/controls/Line/Line.js
+++ b/packages/carbon-graphs/src/js/controls/Line/Line.js
@@ -50,7 +50,7 @@ import LineConfig from './LineConfig';
  * @returns {object} - Contains min and max values for the data points for Y and Y2 axis
  */
 const calculateValuesRange = (values, axis = constants.Y_AXIS) => {
-  const yAxisValuesList = values.filter((i) => i.y !== null).map((i) => i.y);
+  const yAxisValuesList = values.filter((i) => i.y !== null && i.y !== undefined).map((i) => i.y);
   return {
     [axis]: {
       min: Math.min(...yAxisValuesList),
@@ -266,7 +266,7 @@ class Line extends GraphContent {
         .select(`g[aria-describedby="${graphData.key}"]`)
         .select(`.${styles.currentPointsGroup}`)
         .selectAll(`[class*="${styles.point}"]`)
-        .data(getDataPointValues(this.dataTarget));
+        .data(getDataPointValues(this.dataTarget).filter((d) => d.y !== null && d.y !== undefined));
       drawDataPoints(graph.scale, graph.config, pointPath.enter(), graph.legendSVG);
       pointPath
         .exit()

--- a/packages/carbon-graphs/src/js/controls/Line/helpers/helpers.js
+++ b/packages/carbon-graphs/src/js/controls/Line/helpers/helpers.js
@@ -63,7 +63,7 @@ const getDataPointValues = (target) => target.internalValuesSubset;
 const createLine = (scale, d) => {
   const newLine = d3
     .line()
-    .defined((value) => value.y !== null)
+    .defined((value) => value.y !== null && value.y !== undefined)
     .x((value) => scale.x(value.x))
     .y((value) => scale[value.yAxis](value.y))
     .curve(d.interpolationType);
@@ -363,7 +363,7 @@ const draw = (scale, config, canvasSVG, dataTarget, legendSVG) => {
     const pointPath = lineSVG
       .select(`.${styles.currentPointsGroup}`)
       .selectAll(`.${styles.point}`)
-      .data(getDataPointValues(dataTarget).filter((d) => d.y !== null));
+      .data(getDataPointValues(dataTarget).filter((d) => d.y !== null && d.y !== undefined));
     drawDataPoints(scale, config, pointPath.enter(), legendSVG);
     pointPath
       .exit()

--- a/packages/carbon-graphs/src/js/controls/PairedResult/PairedResult.js
+++ b/packages/carbon-graphs/src/js/controls/PairedResult/PairedResult.js
@@ -39,6 +39,8 @@ import {
   calculateVerticalPadding,
   getXAxisXPosition,
 } from '../../helpers/axis';
+import { validatePairedResultData } from "../../helpers/constructUtils";
+
 
 /**
  * @typedef {object} PairedResult
@@ -158,6 +160,7 @@ class PairedResult extends GraphContent {
      * @inheritdoc
      */
   load(graph) {
+    validatePairedResultData(this.config.values);
     this.dataTarget = processDataPoints(graph.config, this.config);
     draw(graph.scale, graph.config, graph.svg, this.dataTarget);
     if (
@@ -294,6 +297,7 @@ class PairedResult extends GraphContent {
     const reflow = !!this.config.values.length;
     this.config.values = utils.deepClone(graphData.values);
     this.config.values = filterPairedResultData(this.config.values);
+    validatePairedResultData(this.config.values);
     this.dataTarget = processDataPoints(graph.config, this.config, reflow);
     const drawBox = (boxPath) => {
       drawSelectionIndicator(graph.scale, graph.config, boxPath);

--- a/packages/carbon-graphs/src/js/controls/Scatter/Scatter.js
+++ b/packages/carbon-graphs/src/js/controls/Scatter/Scatter.js
@@ -29,6 +29,7 @@ import {
   getDataPointValues,
 } from './helpers/helpers';
 import ScatterConfig from './ScatterConfig';
+import { validateData } from "../../helpers/constructUtils";
 
 /**
  * @typedef {object} Scatter
@@ -104,6 +105,7 @@ class Scatter extends GraphContent {
      * @inheritdoc
      */
   load(graph) {
+    validateData(this.config.values);
     this.dataTarget = processDataPoints(graph.config, this.config);
     draw(graph.scale, graph.config, graph.svg, this.dataTarget);
     if (utils.notEmpty(this.dataTarget.regions)) {
@@ -189,6 +191,7 @@ class Scatter extends GraphContent {
      */
   reflow(graph, graphData) {
     this.config.values = graphData.values;
+    validateData(this.config.values);
     const eventHandlers = {
       clickHandler: clickHandler(graph, this, graph.config, graph.svg),
       hoverHandler: hoverHandler(graph.config.shownTargets, graph.svg),

--- a/packages/carbon-graphs/src/js/controls/Scatter/helpers/helpers.js
+++ b/packages/carbon-graphs/src/js/controls/Scatter/helpers/helpers.js
@@ -281,7 +281,7 @@ const draw = (scale, config, canvasSVG, dataTarget, legendSVG) => {
   const pointPath = scatterSVG
     .select(`.${styles.currentPointsGroup}`)
     .selectAll(`.${styles.point}`)
-    .data(getDataPointValues(dataTarget).filter((d) => d.y !== null));
+    .data(getDataPointValues(dataTarget));
   drawDataPoints(scale, config, pointPath.enter(), legendSVG);
   pointPath
     .exit()

--- a/packages/carbon-graphs/src/js/helpers/constructUtils.js
+++ b/packages/carbon-graphs/src/js/helpers/constructUtils.js
@@ -4,6 +4,9 @@
  */
 
 import utils from './utils';
+import errors from "./errors";
+import { iterateOnPairType } from '../controls/PairedResult/helpers/helpers.js';
+import {getValue} from "../controls/PairedResult/helpers/helpers";
 
 /**
  * Simple utility that checks if the input is an array or objects or simple object.
@@ -21,4 +24,35 @@ const contentHandler = (input, task) => {
   }
 };
 
-export { contentHandler };
+/**
+ * validates data passed by consumer.
+ *
+ * @param {object} data - Data points object
+ * @returns {undefined} returns nothing
+ */
+const validateData = (data) => {
+  data.map((value) => {
+    if(utils.isEmpty(value.y)) {
+      throw new Error(errors.THROW_MSG_INVALID_DATA);
+    }
+  });
+}
+
+/**
+ * validates paired result data passed by consumer.
+ *
+ * @param {object} data - Data points object
+ * @returns {undefined} returns nothing
+ */
+const validatePairedResultData = (data) => {
+  data.map((value) => {
+    iterateOnPairType((t) => {
+      if (utils.isDefined(getValue(value, t))) {
+        if(utils.isEmpty(value[t].y)){
+          throw new Error(errors.THROW_MSG_INVALID_DATA);
+        }
+      }
+    });
+  });
+}
+export { contentHandler, validateData, validatePairedResultData };

--- a/packages/carbon-graphs/src/js/helpers/errors.js
+++ b/packages/carbon-graphs/src/js/helpers/errors.js
@@ -83,6 +83,8 @@ export default {
         'Clone input function has not been implemented.',
   THROW_MSG_INVALID_LOAD_CONTENT_AT_INDEX:
         'Invalid input provided. Content cannot be loaded at index less than zero.',
+  THROW_MSG_INVALID_DATA:
+      'Invalid data provided, data cannot consists of values like null/undefined',
   /**
      * @description Region
      */

--- a/packages/carbon-graphs/tests/unit/controls/Bar/BarLoad-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Bar/BarLoad-spec.js
@@ -24,6 +24,8 @@ import {
   valuesDefault,
   valuesTimeSeries,
 } from './helpers';
+import Scatter from "../../../../src/js/controls/Scatter";
+import errors from "../../../../src/js/helpers/errors";
 
 describe('Bar - Load lifecycle', () => {
   let graphDefault = null;
@@ -49,6 +51,28 @@ describe('Bar - Load lifecycle', () => {
     const loadedBar = new Bar(getInput(valuesDefault, false, false));
     loadedBar.load(graphDefault);
     expect(loadedBar instanceof Bar).toBeTruthy();
+  });
+  it('throws error when null value is passed as y', () => {
+    let input = null;
+    expect(() => {
+      graphDefault.destroy();
+      const graph = new Graph(getAxes(axisDefault));
+      const data = utils.deepClone(valuesDefault);
+      data[0].y = null;
+      input = getInput(data);
+      graph.loadContent(new Bar(input));
+    }).toThrowError(errors.THROW_MSG_INVALID_DATA);
+  });
+  it('throws error when undefined value is passed as y', () => {
+    let input = null;
+    expect(() => {
+      graphDefault.destroy();
+      const graph = new Graph(getAxes(axisDefault));
+      const data = utils.deepClone(valuesDefault);
+      data[0].y = undefined;
+      input = getInput(data);
+      graph.loadContent(new Bar(input));
+    }).toThrowError(errors.THROW_MSG_INVALID_DATA);
   });
   it('internal subsets gets created correctly for each data point', () => {
     const graph = graphDefault.loadContent(

--- a/packages/carbon-graphs/tests/unit/controls/Bar/BarLoad-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Bar/BarLoad-spec.js
@@ -24,7 +24,6 @@ import {
   valuesDefault,
   valuesTimeSeries,
 } from './helpers';
-import Scatter from "../../../../src/js/controls/Scatter";
 import errors from "../../../../src/js/helpers/errors";
 
 describe('Bar - Load lifecycle', () => {
@@ -55,23 +54,19 @@ describe('Bar - Load lifecycle', () => {
   it('throws error when null value is passed as y', () => {
     let input = null;
     expect(() => {
-      graphDefault.destroy();
-      const graph = new Graph(getAxes(axisDefault));
       const data = utils.deepClone(valuesDefault);
       data[0].y = null;
       input = getInput(data);
-      graph.loadContent(new Bar(input));
+      graphDefault.loadContent(new Bar(input));
     }).toThrowError(errors.THROW_MSG_INVALID_DATA);
   });
   it('throws error when undefined value is passed as y', () => {
     let input = null;
     expect(() => {
-      graphDefault.destroy();
-      const graph = new Graph(getAxes(axisDefault));
       const data = utils.deepClone(valuesDefault);
       data[0].y = undefined;
       input = getInput(data);
-      graph.loadContent(new Bar(input));
+      graphDefault.loadContent(new Bar(input));
     }).toThrowError(errors.THROW_MSG_INVALID_DATA);
   });
   it('internal subsets gets created correctly for each data point', () => {

--- a/packages/carbon-graphs/tests/unit/controls/Bar/BarPanning-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Bar/BarPanning-spec.js
@@ -20,6 +20,7 @@ import {
 } from './helpers';
 import { getSVGAnimatedTransformList } from '../../../../src/js/helpers/transformUtils';
 import { COLORS, SHAPES } from '../../../../src/js/helpers/constants';
+import errors from "../../../../src/js/helpers/errors";
 
 describe('Bar - Panning', () => {
   let graphDefault = null;
@@ -60,6 +61,40 @@ describe('Bar - Panning', () => {
     });
     it('Check if clamp is false if pan is enabled', () => {
       expect(graphDefault.scale.x.clamp()).toEqual(false);
+    });
+    it('throws error when null value is passed as y', () => {
+      const panData = {
+        key: 'uid_1',
+        values: [
+          {
+            x: '2016-03-03T12:00:00Z',
+            y: null,
+          },
+          {
+            x: '2016-04-03T12:00:00Z',
+            y: 20,
+          },
+        ],
+      };
+
+      expect(() => {graphDefault.reflow(panData)}).toThrowError(errors.THROW_MSG_INVALID_DATA);
+    });
+    it('throws error when undefined value is passed as y', () => {
+      const panData = {
+        key: 'uid_1',
+        values: [
+          {
+            x: '2016-03-03T12:00:00Z',
+            y: undefined,
+          },
+          {
+            x: '2016-04-03T12:00:00Z',
+            y: 20,
+          },
+        ],
+      };
+
+      expect(() => {graphDefault.reflow(panData)}).toThrowError(errors.THROW_MSG_INVALID_DATA);
     });
     it('DatelineGroup translates properly when panning is enabled', (done) => {
       const datelineGroup = document.querySelector(

--- a/packages/carbon-graphs/tests/unit/controls/Bubble/MultipleDataset/BubbleMultipleDatasetLoad-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Bubble/MultipleDataset/BubbleMultipleDatasetLoad-spec.js
@@ -77,6 +77,28 @@ describe('Bubble Multiple Dataset - Load', () => {
       validGraph.loadContent(new BubbleMultipleDataset(input));
     }).toThrowError(errors.THROW_MSG_INVALID_FORMAT_TYPE);
   });
+  it('throws error when y values is passed as null', () => {
+    let input = null;
+    expect(() => {
+      graphDefault.destroy();
+      const graph = new Graph(getAxes(axisDefault));
+      const data = utils.deepClone(valuesDefault);
+      data[0].y = null;
+      input = getInput(data);
+      graph.loadContent(new BubbleMultipleDataset(input));
+    }).toThrowError(errors.THROW_MSG_INVALID_DATA);
+  });
+  it('throws error when y values is passed as undefined', () => {
+    let input = null;
+    expect(() => {
+      graphDefault.destroy();
+      const graph = new Graph(getAxes(axisDefault));
+      const data = utils.deepClone(valuesDefault);
+      data[0].y = undefined;
+      input = getInput(data);
+      graph.loadContent(new BubbleMultipleDataset(input));
+    }).toThrowError(errors.THROW_MSG_INVALID_DATA);
+  });
   it('internal subsets gets created correctly for each data point', () => {
     const graph = graphDefault.loadContent(
       new BubbleMultipleDataset(getInput(valuesDefault, false, false)),
@@ -198,18 +220,6 @@ describe('Bubble Multiple Dataset - Load', () => {
       expect(bubbleGroup).not.toBeNull();
       expect(bubbleGroup.tagName).toBe('g');
       expect(bubbleGroup.getAttribute('transform')).not.toBeNull();
-    });
-    it('does not show data point if data point is null', () => {
-      graphDefault.destroy();
-      const graph = new Graph(getAxes(axisDefault));
-      const data = utils.deepClone(valuesDefault);
-      data[0].y = null;
-      input = getInput(data);
-      graph.loadContent(new BubbleMultipleDataset(input));
-      const pointsGroups = bubbleGraphContainer.querySelectorAll(
-                `.${styles.point}`,
-      );
-      expect(pointsGroups.length).toBe(2);
     });
     it('add points group for data points', () => {
       const pointsGroup = fetchElementByClass(
@@ -510,115 +520,6 @@ describe('Bubble Multiple Dataset - Load', () => {
             );
             done();
           });
-        });
-      });
-    });
-    describe('When values are non-contiguous', () => {
-      const axis = {
-        x: {
-          label: 'Some X Label',
-          lowerLimit: 0,
-          upperLimit: 100,
-        },
-        y: {
-          label: 'Some Y Label',
-          lowerLimit: 20,
-          upperLimit: 200,
-        },
-        y2: {
-          show: true,
-          label: 'Some Y2 Label',
-          lowerLimit: 20,
-          upperLimit: 200,
-        },
-      };
-      const values = [
-        { x: 35, y: 40 },
-        { x: 55, y: 50 },
-        { x: 45, y: null },
-        { x: 25, y: 100 },
-        { x: 45, y: 150 },
-      ];
-      describe('In Y Axis', () => {
-        it('Displays graph properly', () => {
-          graphDefault.destroy();
-          const graph = new Graph(getAxes(axis));
-          input = getInput(values, true, false);
-          input.values = values;
-          graph.loadContent(new BubbleMultipleDataset(input));
-          graph.resize();
-          const bubbleGroup = bubbleGraphContainer.querySelectorAll(
-                        `.${styles.bubbleGraphContent}`,
-          );
-          expect(bubbleGroup.length).toBe(1);
-          expect(
-            bubbleGraphContainer.querySelectorAll(
-                            `.${styles.point}`,
-            ).length,
-          ).toBe(4);
-          expect(graph.config.axis.y.domain.lowerLimit).toBe(11);
-          expect(graph.config.axis.y.domain.upperLimit).toBe(209);
-        });
-        it('Displays graph properly without domain padding', () => {
-          graphDefault.destroy();
-          const data = getAxes(axis);
-          data.axis.y.padDomain = false;
-          const graph = new Graph(data);
-          input = getInput(values, true, true, false);
-          input.values = values;
-          graph.loadContent(new BubbleMultipleDataset(input));
-          graph.resize();
-          const bubbleGroup = bubbleGraphContainer.querySelectorAll(
-                        `.${styles.bubbleGraphContent}`,
-          );
-          expect(bubbleGroup.length).toBe(1);
-          expect(
-            bubbleGraphContainer.querySelectorAll(
-                            `.${styles.point}`,
-            ).length,
-          ).toBe(4);
-          expect(graph.config.axis.y.domain.lowerLimit).toBe(20);
-          expect(graph.config.axis.y.domain.upperLimit).toBe(200);
-        });
-      });
-      describe('In Y2 Axis', () => {
-        it('Displays graph properly', () => {
-          graphDefault.destroy();
-          const graph = new Graph(getAxes(axis));
-          input = getInput(values, true, true, true);
-          graph.loadContent(new BubbleMultipleDataset(input));
-          graph.resize();
-          const bubbleGroup = bubbleGraphContainer.querySelectorAll(
-                        `.${styles.bubbleGraphContent}`,
-          );
-          expect(bubbleGroup.length).toBe(1);
-          expect(
-            bubbleGraphContainer.querySelectorAll(
-                            `.${styles.point}`,
-            ).length,
-          ).toBe(4);
-          expect(graph.config.axis.y2.domain.lowerLimit).toBe(11);
-          expect(graph.config.axis.y2.domain.upperLimit).toBe(209);
-        });
-        it('Displays graph properly without domain padding', () => {
-          graphDefault.destroy();
-          const data = getAxes(axis);
-          data.axis.y2.padDomain = false;
-          const graph = new Graph(data);
-          input = getInput(values, true, true, true);
-          graph.loadContent(new BubbleMultipleDataset(input));
-          graph.resize();
-          const bubbleGroup = bubbleGraphContainer.querySelectorAll(
-                        `.${styles.bubbleGraphContent}`,
-          );
-          expect(bubbleGroup.length).toBe(1);
-          expect(
-            bubbleGraphContainer.querySelectorAll(
-                            `.${styles.point}`,
-            ).length,
-          ).toBe(4);
-          expect(graph.config.axis.y2.domain.lowerLimit).toBe(20);
-          expect(graph.config.axis.y2.domain.upperLimit).toBe(200);
         });
       });
     });

--- a/packages/carbon-graphs/tests/unit/controls/Bubble/MultipleDataset/BubbleMultipleDatasetPanning-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Bubble/MultipleDataset/BubbleMultipleDatasetPanning-spec.js
@@ -20,6 +20,7 @@ import {
   fetchAllElementsByClass,
   fetchElementByClass,
 } from '../helpers';
+import errors from "../../../../../src/js/helpers/errors";
 
 describe('Bubble Multiple Dataset- Panning', () => {
   let graphDefault = null;
@@ -81,6 +82,38 @@ describe('Bubble Multiple Dataset- Panning', () => {
         expect(toNumber(translate[1], 10)).toBeCloseTo(PADDING_BOTTOM);
         done();
       });
+    });
+    it('throws error when null value is passed as y', () => {
+      const panData = {
+        key: 'uid_1',
+        values: [
+          {
+            x: '2016-03-03T12:00:00Z',
+            y: null,
+          },
+          {
+            x: '2016-04-03T12:00:00Z',
+            y: 20,
+          },
+        ],
+      };
+      expect(() => {graphDefault.reflow(panData)}).toThrowError(errors.THROW_MSG_INVALID_DATA);
+    });
+    it('throws error when undefined value is passed as y', () => {
+      const panData = {
+        key: 'uid_1',
+        values: [
+          {
+            x: '2016-03-03T12:00:00Z',
+            y: undefined,
+          },
+          {
+            x: '2016-04-03T12:00:00Z',
+            y: 20,
+          },
+        ],
+      };
+      expect(() => {graphDefault.reflow(panData)}).toThrowError(errors.THROW_MSG_INVALID_DATA);
     });
     describe('when key matches', () => {
       describe('label is not passed', () => {

--- a/packages/carbon-graphs/tests/unit/controls/Bubble/SingleDataset/BubbleSingleDatasetLoad-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Bubble/SingleDataset/BubbleSingleDatasetLoad-spec.js
@@ -2,7 +2,7 @@
 
 import sinon from 'sinon';
 import Graph from '../../../../../src/js/controls/Graph/Graph';
-import { BubbleSingleDataset } from '../../../../../src/js/controls/Bubble';
+import {BubbleMultipleDataset, BubbleSingleDataset} from '../../../../../src/js/controls/Bubble';
 import constants, {
   AXIS_TYPE,
   BUBBLE,
@@ -81,6 +81,28 @@ describe('Bubble Single Dataset - Load', () => {
       const validGraph = new Graph(getAxes(utils.deepClone(axisDefault)));
       validGraph.loadContent(new BubbleSingleDataset(input));
     }).toThrowError(errors.THROW_MSG_INVALID_FORMAT_TYPE);
+  });
+  it('throws error when y values is passed as null', () => {
+    let input = null;
+    expect(() => {
+      graphDefault.destroy();
+      const graph = new Graph(getAxes(axisDefault));
+      const data = utils.deepClone(valuesDefault);
+      data[0].y = null;
+      input = getInput(data);
+      graph.loadContent(new BubbleSingleDataset(input));
+    }).toThrowError(errors.THROW_MSG_INVALID_DATA);
+  });
+  it('throws error when y values is passed as undefined', () => {
+    let input = null;
+    expect(() => {
+      graphDefault.destroy();
+      const graph = new Graph(getAxes(axisDefault));
+      const data = utils.deepClone(valuesDefault);
+      data[0].y = undefined;
+      input = getInput(data);
+      graph.loadContent(new BubbleSingleDataset(input));
+    }).toThrowError(errors.THROW_MSG_INVALID_DATA);
   });
   it('internal subsets gets created correctly for each data point', () => {
     const graph = graphDefault.loadContent(
@@ -178,19 +200,6 @@ describe('Bubble Single Dataset - Load', () => {
       expect(bubbleGroup).not.toBeNull();
       expect(bubbleGroup.tagName).toBe('g');
       expect(bubbleGroup.getAttribute('transform')).not.toBeNull();
-    });
-
-    it('does not show data point if data point is null', () => {
-      graphDefault.destroy();
-      const graph = new Graph(getAxes(axisDefault));
-      const data = utils.deepClone(valuesDefault);
-      data[0].y = null;
-      input = getInput(data);
-      graph.loadContent(new BubbleSingleDataset(input));
-      const pointsGroups = bubbleGraphContainer.querySelectorAll(
-                `.${styles.point}`,
-      );
-      expect(pointsGroups.length).toBe(2);
     });
     it('add points group for data points', () => {
       const pointsGroup = fetchElementByClass(
@@ -539,75 +548,6 @@ describe('Bubble Single Dataset - Load', () => {
             );
             done();
           });
-        });
-      });
-    });
-    describe('When values are non-contiguous', () => {
-      const axis = {
-        x: {
-          label: 'Some X Label',
-          lowerLimit: 0,
-          upperLimit: 100,
-        },
-        y: {
-          label: 'Some Y Label',
-          lowerLimit: 20,
-          upperLimit: 200,
-        },
-        y2: {
-          show: true,
-          label: 'Some Y2 Label',
-          lowerLimit: 20,
-          upperLimit: 200,
-        },
-      };
-      const values = [
-        { x: 35, y: 40 },
-        { x: 55, y: 50 },
-        { x: 45, y: null },
-        { x: 25, y: 100 },
-        { x: 45, y: 150 },
-      ];
-      describe('In Y Axis', () => {
-        it('Displays graph properly', () => {
-          graphDefault.destroy();
-          const graph = new Graph(getAxes(axis));
-          input = getInput(values, true, false);
-          input.values = values;
-          graph.loadContent(new BubbleSingleDataset(input));
-          graph.resize();
-          const bubbleGroup = bubbleGraphContainer.querySelectorAll(
-                        `.${styles.bubbleGraphContent}`,
-          );
-          expect(bubbleGroup.length).toBe(1);
-          expect(
-            bubbleGraphContainer.querySelectorAll(
-                            `.${styles.point}`,
-            ).length,
-          ).toBe(4);
-          expect(graph.config.axis.y.domain.lowerLimit).toBe(11);
-          expect(graph.config.axis.y.domain.upperLimit).toBe(209);
-        });
-        it('Displays graph properly without domain padding', () => {
-          graphDefault.destroy();
-          const data = getAxes(axis);
-          data.axis.y.padDomain = false;
-          const graph = new Graph(data);
-          input = getInput(values, true, true, false);
-          input.values = values;
-          graph.loadContent(new BubbleSingleDataset(input));
-          graph.resize();
-          const bubbleGroup = bubbleGraphContainer.querySelectorAll(
-                        `.${styles.bubbleGraphContent}`,
-          );
-          expect(bubbleGroup.length).toBe(1);
-          expect(
-            bubbleGraphContainer.querySelectorAll(
-                            `.${styles.point}`,
-            ).length,
-          ).toBe(4);
-          expect(graph.config.axis.y.domain.lowerLimit).toBe(20);
-          expect(graph.config.axis.y.domain.upperLimit).toBe(200);
         });
       });
     });

--- a/packages/carbon-graphs/tests/unit/controls/Bubble/SingleDataset/BubbleSingleDatasetPanning-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Bubble/SingleDataset/BubbleSingleDatasetPanning-spec.js
@@ -20,6 +20,7 @@ import {
   fetchAllElementsByClass,
   fetchElementByClass,
 } from '../helpers';
+import errors from "../../../../../src/js/helpers/errors";
 
 describe('Bubble Single Dataset - Panning', () => {
   let graphDefault = null;
@@ -81,6 +82,38 @@ describe('Bubble Single Dataset - Panning', () => {
         expect(toNumber(translate[1], 10)).toBeCloseTo(PADDING_BOTTOM);
         done();
       });
+    });
+    it('throws error when null value is passed as y', () => {
+      const panData = {
+        key: 'uid_1',
+        values: [
+          {
+            x: '2016-03-03T12:00:00Z',
+            y: null,
+          },
+          {
+            x: '2016-04-03T12:00:00Z',
+            y: 20,
+          },
+        ],
+      };
+      expect(() => {graphDefault.reflow(panData)}).toThrowError(errors.THROW_MSG_INVALID_DATA);
+    });
+    it('throws error when undefined value is passed as y', () => {
+      const panData = {
+        key: 'uid_1',
+        values: [
+          {
+            x: '2016-03-03T12:00:00Z',
+            y: undefined,
+          },
+          {
+            x: '2016-04-03T12:00:00Z',
+            y: 20,
+          },
+        ],
+      };
+      expect(() => {graphDefault.reflow(panData)}).toThrowError(errors.THROW_MSG_INVALID_DATA);
     });
     describe('when key matches', () => {
       describe('label is not passed', () => {

--- a/packages/carbon-graphs/tests/unit/controls/Graph/GraphPanning-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Graph/GraphPanning-spec.js
@@ -122,11 +122,9 @@ describe('Graph - Panning', () => {
         };
         graph.reflow(panData);
         eventlines = document.querySelectorAll(`.${styles.eventline}`);
-        console.log(eventlines);
         expect(eventlines.length).toBe(2);
       });
       it("Removes the eventline when empty dataset is passed", () => {
-        console.log("Before: ", graph.config.eventline);
         let eventlines = document.querySelectorAll(`.${styles.eventline}`);
         expect(eventlines.length).toBe(1);
         const panData = {
@@ -134,7 +132,6 @@ describe('Graph - Panning', () => {
         };
         graph.reflow(panData);
         eventlines = document.querySelectorAll(`.${styles.eventline}`);
-        console.log("After: ", graph.config.eventline);
         expect(eventlines.length).toBe(0);
       });
     });

--- a/packages/carbon-graphs/tests/unit/controls/Line/LineLoad-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Line/LineLoad-spec.js
@@ -257,6 +257,24 @@ describe('Line - Load', () => {
       expect(pointsGroup.children.length).toBe(valuesDefault.length - 1);
       expect(selectedPoint.getAttribute('aria-hidden')).toContain('true');
     });
+    it('does not render data point if data point is undefiend', () => {
+      graphDefault.destroy();
+      const graph = new Graph(getAxes(axisDefault));
+      const data = utils.deepClone(valuesDefault);
+      data[0].y = undefined;
+      input = getInput(data);
+      graph.loadContent(new Line(input));
+      const pointsGroup = fetchElementByClass(
+        lineGraphContainer,
+        styles.currentPointsGroup,
+      );
+      const selectedPoint = fetchElementByClass(
+        pointsGroup,
+        styles.dataPointSelection,
+      );
+      expect(pointsGroup.children.length).toBe(valuesDefault.length - 1);
+      expect(selectedPoint.getAttribute('aria-hidden')).toContain('true');
+    });
     it('does not render points if shapes needs to be hidden', () => {
       graphDefault.destroy();
       const hiddenShapeInput = getAxes(axisDefault);

--- a/packages/carbon-graphs/tests/unit/controls/Line/LinePanning-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Line/LinePanning-spec.js
@@ -283,6 +283,57 @@ describe('Line - Panning', () => {
       });
     });
   });
+  describe("When values are non-contiguous", () => {
+    beforeEach(() => {
+      const axisData = utils.deepClone(getAxes(axisTimeSeries));
+      axisData.pan = { enabled: true };
+      const input = getInput([], false, false);
+      graphDefault = new Graph(axisData);
+      graphDefault.loadContent(new Line(input));
+    });
+    it("should remove datapoint with y value as null", () => {
+      const panData = {
+        key: "uid_1",
+        values: [
+          {
+            x: "2016-03-03T12:00:00Z",
+            y: null
+          },
+          {
+            x: "2016-04-03T12:00:00Z",
+            y: 20
+          }
+        ]
+      };
+      graphDefault.reflow(panData);
+      let lineContent = fetchAllElementsByClass(
+        lineGraphContainer,
+        styles.pointGroup
+      );
+      expect(lineContent.length).toEqual(panData.values.length-1);
+    });
+    it("should remove datapoint with y value as null", () => {
+      const panData = {
+        key: "uid_1",
+        values: [
+          {
+            x: "2016-03-03T12:00:00Z",
+            y: undefined
+          },
+          {
+            x: "2016-04-03T12:00:00Z",
+            y: 20
+          }
+        ]
+      };
+      graphDefault.reflow(panData);
+      let lineContent = fetchAllElementsByClass(
+        lineGraphContainer,
+        styles.pointGroup
+      );
+      expect(lineContent.length).toEqual(panData.values.length-1);
+    });
+  });
   describe('When pan is disabled', () => {
     beforeEach(() => {
       const axisData = utils.deepClone(getAxes(axisTimeSeries));

--- a/packages/carbon-graphs/tests/unit/controls/PairedResult/PairedResult-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/PairedResult/PairedResult-spec.js
@@ -62,7 +62,139 @@ describe('PairedResult', () => {
       input.values = [];
       expect(() => {
         graphDefault.loadContent(new PairedResult(input));
-      }).not.toThrow();
+      }).not.toThrow(errors.THROW_MSG_UNIQUE_KEY_NOT_PROVIDED);
+    });
+    describe('For Paired result high', () => {
+      it('throw an error when null value is provided for y', () => {
+        expect(() => {
+          const graphTimeSeries = new Graph(getAxes(axisTimeSeries));
+          graphTimeSeries.loadContent(
+            new PairedResult(
+              getInput(
+                [
+                  {
+                    high: {
+                      x: '2016-02-03T12:00:00.000Z',
+                      y: null,
+                    },
+                  },
+                ],
+                false,
+                false,
+              ),
+            ),
+          );
+        }).toThrowError(errors.THROW_MSG_INVALID_DATA);
+      });
+      it('throw an error when undeifned value is provided for y', () => {
+        expect(() => {
+          const graphTimeSeries = new Graph(getAxes(axisTimeSeries));
+          graphTimeSeries.loadContent(
+            new PairedResult(
+              getInput(
+                [
+                  {
+                    high: {
+                      x: '2016-02-03T12:00:00.000Z',
+                      y: undefined,
+                    },
+                  },
+                ],
+                false,
+                false,
+              ),
+            ),
+          );
+        }).toThrowError(errors.THROW_MSG_INVALID_DATA);
+      });
+    });
+    describe('For Paired result mid', () => {
+      it('throw an error when null value is provided for y', () => {
+        expect(() => {
+          const graphTimeSeries = new Graph(getAxes(axisTimeSeries));
+          graphTimeSeries.loadContent(
+            new PairedResult(
+              getInput(
+                [
+                  {
+                    mid: {
+                      x: '2016-02-03T12:00:00.000Z',
+                      y: null,
+                    },
+                  },
+                ],
+                false,
+                false,
+              ),
+            ),
+          );
+        }).toThrowError(errors.THROW_MSG_INVALID_DATA);
+      });
+      it('throw an error when undefined value is provided for y', () => {
+        expect(() => {
+          const graphTimeSeries = new Graph(getAxes(axisTimeSeries));
+          graphTimeSeries.loadContent(
+            new PairedResult(
+              getInput(
+                [
+                  {
+                    mid: {
+                      x: '2016-02-03T12:00:00.000Z',
+                      y: undefined,
+                    },
+                  },
+                ],
+                false,
+                false,
+              ),
+            ),
+          );
+        }).toThrowError(errors.THROW_MSG_INVALID_DATA);
+      });
+    });
+    describe('For Paired result low', () => {
+      it('throw an error when null value is provided for y', () => {
+        expect(() => {
+          const graphTimeSeries = new Graph(getAxes(axisTimeSeries));
+          graphTimeSeries.loadContent(
+            new PairedResult(
+              getInput(
+                [
+                  {
+                    low: {
+                      x: '2016-02-03T12:00:00.000Z',
+                      y: null,
+                    },
+                  },
+                ],
+                false,
+                false,
+              ),
+            ),
+          );
+        }).toThrowError(errors.THROW_MSG_INVALID_DATA);
+      });
+      it('throw an error when undefined value is provided for y', () => {
+        expect(() => {
+          const graphTimeSeries = new Graph(getAxes(axisTimeSeries));
+          graphTimeSeries.loadContent(
+            new PairedResult(
+              getInput(
+                [
+                  {
+                    low: {
+                      x: '2016-02-03T12:00:00.000Z',
+                      y: undefined,
+                    },
+                  },
+                ],
+                false,
+                false,
+              ),
+            ),
+          );
+        }).toThrowError(errors.THROW_MSG_INVALID_DATA);
+      });
     });
     it('display the legend when empty array is provided as input', () => {
       const input = utils.deepClone(getInput(valuesDefault));

--- a/packages/carbon-graphs/tests/unit/controls/PairedResult/PairedResultPanning-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/PairedResult/PairedResultPanning-spec.js
@@ -20,6 +20,7 @@ import {
   fetchAllElementsByClass,
   fetchElementByClass,
 } from './helpers';
+import errors from "../../../../src/js/helpers/errors";
 
 describe('PairedResult', () => {
   let graphDefault = null;
@@ -75,7 +76,96 @@ describe('PairedResult', () => {
         done();
       });
     });
-
+    describe('For paired result high', () => {
+      it('throw an error when null value is provided for y', () => {
+        const panData = {
+          key: 'uid_1',
+          values: [
+            {
+              high: {
+                x: '2016-09-17T12:00:00Z',
+                y: null,
+              },
+            },
+          ],
+        };
+        expect(() => {graphDefault.reflow(panData)}).toThrowError(errors.THROW_MSG_INVALID_DATA);
+      });
+      it('throw an error when undefined value is provided for y', () => {
+        const panData = {
+          key: 'uid_1',
+          values: [
+            {
+              high: {
+                x: '2016-09-17T12:00:00Z',
+                y: undefined,
+              },
+            },
+          ],
+        };
+        expect(() => {graphDefault.reflow(panData)}).toThrowError(errors.THROW_MSG_INVALID_DATA);
+      });
+    });
+    describe('For paired result mid', () => {
+      it('throw an error when null value is provided for y', () => {
+        const panData = {
+          key: 'uid_1',
+          values: [
+            {
+              mid: {
+                x: '2016-09-18T12:00:00Z',
+                y: null,
+              },
+            },
+          ],
+        };
+        expect(() => {graphDefault.reflow(panData)}).toThrowError(errors.THROW_MSG_INVALID_DATA);
+      });
+      it('throw an error when undefined value is provided for y', () => {
+        const panData = {
+          key: 'uid_1',
+          values: [
+            {
+              mid: {
+                x: '2016-09-17T12:00:00Z',
+                y: undefined,
+              },
+            },
+          ],
+        };
+        expect(() => {graphDefault.reflow(panData)}).toThrowError(errors.THROW_MSG_INVALID_DATA);
+      });
+    });
+    describe('For paired result low', () => {
+      it('throw an error when null value is provided for y', () => {
+        const panData = {
+          key: 'uid_1',
+          values: [
+            {
+              low: {
+                x: '2016-09-18T12:00:00Z',
+                y: null,
+              },
+            },
+          ],
+        };
+        expect(() => {graphDefault.reflow(panData)}).toThrowError(errors.THROW_MSG_INVALID_DATA);
+      });
+      it('throw an error when undefined value is provided for y', () => {
+        const panData = {
+          key: 'uid_1',
+          values: [
+            {
+              low: {
+                x: '2016-09-17T12:00:00Z',
+                y: undefined,
+              },
+            },
+          ],
+        };
+        expect(() => {graphDefault.reflow(panData)}).toThrowError(errors.THROW_MSG_INVALID_DATA);
+      });
+    });
     describe('when key matches', () => {
       describe('label is not passed', () => {
         it('should update dynamic data and retain label', () => {

--- a/packages/carbon-graphs/tests/unit/controls/Scatter/ScatterLoad-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Scatter/ScatterLoad-spec.js
@@ -21,6 +21,7 @@ import {
   valuesDefault,
   valuesTimeSeries,
 } from './helpers';
+import {BubbleSingleDataset} from "../../../../src/js/controls/Bubble";
 
 describe('Scatter - Load', () => {
   let graphDefault = null;
@@ -60,6 +61,28 @@ describe('Scatter - Load', () => {
       const validGraph = new Graph(getAxes(utils.deepClone(axisDefault)));
       validGraph.loadContent(new Scatter(input));
     }).toThrowError(errors.THROW_MSG_INVALID_FORMAT_TYPE);
+  });
+  it('throws error when null value is passed as y', () => {
+    let input = null;
+    expect(() => {
+      graphDefault.destroy();
+      const graph = new Graph(getAxes(axisDefault));
+      const data = utils.deepClone(valuesDefault);
+      data[0].y = null;
+      input = getInput(data);
+      graph.loadContent(new Scatter(input));
+    }).toThrowError(errors.THROW_MSG_INVALID_DATA);
+  });
+  it('throws error when undefined value is passed as y', () => {
+    let input = null;
+    expect(() => {
+      graphDefault.destroy();
+      const graph = new Graph(getAxes(axisDefault));
+      const data = utils.deepClone(valuesDefault);
+      data[0].y = undefined;
+      input = getInput(data);
+      graph.loadContent(new Scatter(input));
+    }).toThrowError(errors.THROW_MSG_INVALID_DATA);
   });
   it('internal subsets gets created correctly for each data point', () => {
     const graph = graphDefault.loadContent(
@@ -192,24 +215,6 @@ describe('Scatter - Load', () => {
       expect(scatterGroup).not.toBeNull();
       expect(scatterGroup.tagName).toBe('g');
       expect(scatterGroup.getAttribute('transform')).not.toBeNull();
-    });
-    it('does not show data point if data point is null', () => {
-      graphDefault.destroy();
-      const graph = new Graph(getAxes(axisDefault));
-      const data = utils.deepClone(valuesDefault);
-      data[0].y = null;
-      input = getInput(data);
-      graph.loadContent(new Scatter(input));
-      const pointsGroup = fetchElementByClass(
-        scatterGraphContainer,
-        styles.currentPointsGroup,
-      );
-      const selectedPoint = fetchElementByClass(
-        pointsGroup,
-        styles.dataPointSelection,
-      );
-      expect(pointsGroup.children.length).toBe(valuesDefault.length - 1);
-      expect(selectedPoint.getAttribute('aria-hidden')).toContain('true');
     });
     it('add points group for data points', () => {
       const pointsGroup = fetchElementByClass(
@@ -467,115 +472,6 @@ describe('Scatter - Load', () => {
             );
             done();
           });
-        });
-      });
-    });
-    describe('When values are non-contiguous', () => {
-      const axis = {
-        x: {
-          label: 'Some X Label',
-          lowerLimit: 0,
-          upperLimit: 100,
-        },
-        y: {
-          label: 'Some Y Label',
-          lowerLimit: 20,
-          upperLimit: 200,
-        },
-        y2: {
-          show: true,
-          label: 'Some Y2 Label',
-          lowerLimit: 20,
-          upperLimit: 200,
-        },
-      };
-      const values = [
-        { x: 35, y: 40 },
-        { x: 55, y: 50 },
-        { x: 45, y: null },
-        { x: 25, y: 100 },
-        { x: 45, y: 150 },
-      ];
-      describe('In Y Axis', () => {
-        it('Displays graph properly', () => {
-          graphDefault.destroy();
-          const graph = new Graph(getAxes(axis));
-          input = getInput(values, true, true, false);
-          input.values = values;
-          graph.loadContent(new Scatter(input));
-          graph.resize();
-          const scatterGroup = scatterGraphContainer.querySelectorAll(
-                        `.${styles.currentPointsGroup}`,
-          );
-          expect(scatterGroup.length).toBe(1);
-          expect(
-            scatterGraphContainer.querySelectorAll(
-                            `.${styles.point}`,
-            ).length,
-          ).toBe(values.length - 1);
-          expect(graph.config.axis.y.domain.lowerLimit).toBe(11);
-          expect(graph.config.axis.y.domain.upperLimit).toBe(209);
-        });
-        it('Displays graph properly without domain padding', () => {
-          graphDefault.destroy();
-          const data = getAxes(axis);
-          data.axis.y.padDomain = false;
-          const graph = new Graph(data);
-          input = getInput(values, true, true, false);
-          input.values = values;
-          graph.loadContent(new Scatter(input));
-          graph.resize();
-          const scatterGroup = scatterGraphContainer.querySelectorAll(
-                        `.${styles.currentPointsGroup}`,
-          );
-          expect(scatterGroup.length).toBe(1);
-          expect(
-            scatterGraphContainer.querySelectorAll(
-                            `.${styles.point}`,
-            ).length,
-          ).toBe(values.length - 1);
-          expect(graph.config.axis.y.domain.lowerLimit).toBe(20);
-          expect(graph.config.axis.y.domain.upperLimit).toBe(200);
-        });
-      });
-      describe('In Y2 Axis', () => {
-        it('Displays graph properly', () => {
-          graphDefault.destroy();
-          const graph = new Graph(getAxes(axis));
-          input = getInput(values, true, true, true);
-          graph.loadContent(new Scatter(input));
-          graph.resize();
-          const scatterGroup = scatterGraphContainer.querySelectorAll(
-                        `.${styles.currentPointsGroup}`,
-          );
-          expect(scatterGroup.length).toBe(1);
-          expect(
-            scatterGraphContainer.querySelectorAll(
-                            `.${styles.point}`,
-            ).length,
-          ).toBe(values.length - 1);
-          expect(graph.config.axis.y2.domain.lowerLimit).toBe(11);
-          expect(graph.config.axis.y2.domain.upperLimit).toBe(209);
-        });
-        it('Displays graph properly without domain padding', () => {
-          graphDefault.destroy();
-          const data = getAxes(axis);
-          data.axis.y2.padDomain = false;
-          const graph = new Graph(data);
-          input = getInput(values, true, true, true);
-          graph.loadContent(new Scatter(input));
-          graph.resize();
-          const scatterGroup = scatterGraphContainer.querySelectorAll(
-                        `.${styles.currentPointsGroup}`,
-          );
-          expect(scatterGroup.length).toBe(1);
-          expect(
-            scatterGraphContainer.querySelectorAll(
-                            `.${styles.point}`,
-            ).length,
-          ).toBe(values.length - 1);
-          expect(graph.config.axis.y2.domain.lowerLimit).toBe(20);
-          expect(graph.config.axis.y2.domain.upperLimit).toBe(200);
         });
       });
     });

--- a/packages/carbon-graphs/tests/unit/controls/Scatter/ScatterPanning-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Scatter/ScatterPanning-spec.js
@@ -15,6 +15,7 @@ import {
 import { toNumber, delay, PADDING_BOTTOM } from '../../helpers/commonHelpers';
 import { COLORS, SHAPES } from '../../../../src/js/helpers/constants';
 import { getSVGAnimatedTransformList } from '../../../../src/js/helpers/transformUtils';
+import errors from "../../../../src/js/helpers/errors";
 
 describe('Scatter - Panning', () => {
   let graphDefault = null;
@@ -49,6 +50,38 @@ describe('Scatter - Panning', () => {
       const input = getInput(valuesTimeSeries, false, false);
       graphDefault = new Graph(axisData);
       graphDefault.loadContent(new Scatter(input));
+    });
+    it('throws error when null value is passed as y', () => {
+      const panData = {
+        key: 'uid_1',
+        values: [
+          {
+            x: '2016-03-03T12:00:00Z',
+            y: null,
+          },
+          {
+            x: '2016-04-03T12:00:00Z',
+            y: 20,
+          },
+        ],
+      };
+      expect(() => {graphDefault.reflow(panData)}).toThrowError(errors.THROW_MSG_INVALID_DATA);
+    });
+    it('throws error when undefined value is passed as y', () => {
+      const panData = {
+        key: 'uid_1',
+        values: [
+          {
+            x: '2016-03-03T12:00:00Z',
+            y: undefined,
+          },
+          {
+            x: '2016-04-03T12:00:00Z',
+            y: 20,
+          },
+        ],
+      };
+      expect(() => {graphDefault.reflow(panData)}).toThrowError(errors.THROW_MSG_INVALID_DATA);
     });
     it('Check if clamp is false if pan is enabled', () => {
       expect(graphDefault.scale.x.clamp()).toEqual(false);

--- a/packages/terra-graphs/docs/controls/Bar.md
+++ b/packages/terra-graphs/docs/controls/Bar.md
@@ -237,6 +237,8 @@ Each bar can have a legendOptions object in [Values](#values) level.
 | x             | string   | Co-ordinate x, for plotting the bar |
 | y             | string   | Co-ordinate y, for height of bar    |
 
+**Note: providing invalid data to x or y will lead to console error.**
+
 #### Optional
 
 | Property Name | Expected | Default | Description                                           |

--- a/packages/terra-graphs/docs/controls/Bar.md
+++ b/packages/terra-graphs/docs/controls/Bar.md
@@ -237,7 +237,7 @@ Each bar can have a legendOptions object in [Values](#values) level.
 | x             | string   | Co-ordinate x, for plotting the bar |
 | y             | string   | Co-ordinate y, for height of bar    |
 
-**Note: providing invalid data to x or y will lead to console error.**
+**Note: Providing invalid data to x or y will lead to an error.**
 
 #### Optional
 

--- a/packages/terra-graphs/docs/controls/BubbleMultipleDataset.md
+++ b/packages/terra-graphs/docs/controls/BubbleMultipleDataset.md
@@ -254,6 +254,8 @@ weight: {
 | x             | string   | Co-ordinate x, for plotting the data point |
 | y             | string   | Co-ordinate y, for plotting the data point |
 
+**Note: Providing invalid data to x or y will lead to console error.**
+
 #### Optional
 
 | Property Name | Expected | Default   | Description                                                                                                       |

--- a/packages/terra-graphs/docs/controls/BubbleMultipleDataset.md
+++ b/packages/terra-graphs/docs/controls/BubbleMultipleDataset.md
@@ -254,7 +254,7 @@ weight: {
 | x             | string   | Co-ordinate x, for plotting the data point |
 | y             | string   | Co-ordinate y, for plotting the data point |
 
-**Note: Providing invalid data to x or y will lead to console error.**
+**Note: Providing invalid data to x or y will lead to an error.**
 
 #### Optional
 

--- a/packages/terra-graphs/docs/controls/BubbleSingleDataset.md
+++ b/packages/terra-graphs/docs/controls/BubbleSingleDataset.md
@@ -305,7 +305,7 @@ Palette: BUBBLE.PALETTE.ORANGE
 | x             | string   | Co-ordinate x, for plotting the data point |
 | y             | string   | Co-ordinate y, for plotting the data point |
 
-**Note: Providing invalid data to x or y will lead to console error.**
+**Note: providing invalid data to x or y will lead to an error.**
 
 #### Optional
 

--- a/packages/terra-graphs/docs/controls/BubbleSingleDataset.md
+++ b/packages/terra-graphs/docs/controls/BubbleSingleDataset.md
@@ -305,6 +305,8 @@ Palette: BUBBLE.PALETTE.ORANGE
 | x             | string   | Co-ordinate x, for plotting the data point |
 | y             | string   | Co-ordinate y, for plotting the data point |
 
+**Note: Providing invalid data to x or y will lead to console error.**
+
 #### Optional
 
 | Property Name | Expected | Default   | Description                                                                                                       |

--- a/packages/terra-graphs/docs/controls/PairedResult.md
+++ b/packages/terra-graphs/docs/controls/PairedResult.md
@@ -161,7 +161,7 @@ Each paired result can have a style object in [Values](#values) level.
 - At least one of the high/low/medium should be provided with valid data.
 -   `isCritical` toggle is disabled by default
 -   When `isCritical` toggle is enabled, an indicator will be shown surrounding the data point
--   Providing invalid data to x or y will lead to console error.
+-   Providing invalid data to x or y will lead to an error.
 
 
 ### Regions

--- a/packages/terra-graphs/docs/controls/PairedResult.md
+++ b/packages/terra-graphs/docs/controls/PairedResult.md
@@ -161,7 +161,7 @@ Each paired result can have a style object in [Values](#values) level.
 - At least one of the high/low/medium should be provided with valid data.
 -   `isCritical` toggle is disabled by default
 -   When `isCritical` toggle is enabled, an indicator will be shown surrounding the data point
--   Providing invalid data to x or y will lead to console error.**
+-   Providing invalid data to x or y will lead to console error.
 
 
 ### Regions

--- a/packages/terra-graphs/docs/controls/PairedResult.md
+++ b/packages/terra-graphs/docs/controls/PairedResult.md
@@ -161,6 +161,8 @@ Each paired result can have a style object in [Values](#values) level.
 - At least one of the high/low/medium should be provided with valid data.
 -   `isCritical` toggle is disabled by default
 -   When `isCritical` toggle is enabled, an indicator will be shown surrounding the data point
+-   Providing invalid data to x or y will lead to console error.**
+
 
 ### Regions
 

--- a/packages/terra-graphs/docs/controls/Scatter.md
+++ b/packages/terra-graphs/docs/controls/Scatter.md
@@ -159,7 +159,7 @@ Refer [Graph](../core/Graph.md) `Root` for more details.
 | x             | string   | Co-ordinate x, for plotting the data point |
 | y             | string   | Co-ordinate y, for plotting the data point |
 
-**Note: providing invalid data to x or y will lead to console error.**
+**Note: Providing invalid data to x or y will lead to an error.**
 
 #### Optional
 

--- a/packages/terra-graphs/docs/controls/Scatter.md
+++ b/packages/terra-graphs/docs/controls/Scatter.md
@@ -159,6 +159,8 @@ Refer [Graph](../core/Graph.md) `Root` for more details.
 | x             | string   | Co-ordinate x, for plotting the data point |
 | y             | string   | Co-ordinate y, for plotting the data point |
 
+**Note: providing invalid data to x or y will lead to console error.**
+
 #### Optional
 
 | Property Name | Expected | Default | Description                                                |


### PR DESCRIPTION
### Summary
- This issue deals with handling invalid data when passed to y.
- When invalid y data is passed in graphs like bar, paired result, scatter and bubble we will throw an error saying that "Invalid data provided, data cannot consists of values like null/undefined".
- Added functionality for line graphs during reflow to handle null values.

Closes #7 

### Deployment Link

https://terra-graphs-deployed-pr-#.herokuapp.com/

### Testing
- All existing test cases are passing. 
- Tested line type graphs when null/undefined is passed as y value during both initial load and reflow.  
- Test bar, paired result, scatter and bubble graphs when null/undefined is passed as y value during both initial load and 
    reflow. 

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
@cerner/carbon
