### PR TITLE
Fix: Connecting line does not go away for paired results when toggled off in IE

### DIFF
--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -9,7 +9,8 @@
   * Updated `packages/carbon-graphs/README.md` so that it has more essential information about Carbon.
   * Added array handling for loadContent on Construct based graphs.
   * Throw an error when null/undefined/blank is passed as y value.
-  
+  * Connecting line does not go away for paired results when toggled off in Internet Explorer.
+
 ## 2.15.0 - (November 24, 2020)
 
 * Changed

--- a/packages/carbon-graphs/src/js/controls/PairedResult/helpers/helpers.js
+++ b/packages/carbon-graphs/src/js/controls/PairedResult/helpers/helpers.js
@@ -683,7 +683,7 @@ const clickHandler = (graphContext, control, config, canvasSVG) => (
   const pairedBoxGroup = d3.selectAll(`.${styles.pairedBoxGroup}`);
   pairedBoxGroup.each(function () {
     const clipPath = d3.select(this).attr('clip-path');
-    if (clipPath === pairedBoxGroupClipPath) {
+    if (clipPath.replace(/['"]+/g, '') === pairedBoxGroupClipPath) {
       const boxPath = d3.select(this).selectAll(`.${styles.pairedBox}`);
       showLine(config, boxPath);
     }

--- a/packages/carbon-graphs/src/js/controls/PairedResult/helpers/helpers.js
+++ b/packages/carbon-graphs/src/js/controls/PairedResult/helpers/helpers.js
@@ -683,6 +683,8 @@ const clickHandler = (graphContext, control, config, canvasSVG) => (
   const pairedBoxGroup = d3.selectAll(`.${styles.pairedBoxGroup}`);
   pairedBoxGroup.each(function () {
     const clipPath = d3.select(this).attr('clip-path');
+    /* In IE the clip path is encapsulated in quotes (ex: (url(“#carbon-1607926345895-clip"))) and in other browsers it is not.
+    we are using logic below to remove quotes in internet explorer if present. */
     if (clipPath.replace(/['"]+/g, '') === pairedBoxGroupClipPath) {
       const boxPath = d3.select(this).selectAll(`.${styles.pairedBox}`);
       showLine(config, boxPath);

--- a/packages/carbon-graphs/tests/unit/controls/PairedResult/PairedResultLoad-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/PairedResult/PairedResultLoad-spec.js
@@ -2310,4 +2310,18 @@ describe('Paired Result - Load', () => {
       });
     });
   });
+  describe('clip-path', () => {
+    it("should return correct id without quotes ", () => {
+      const inputPrimary = getInput(valuesDefault, false, false);
+      const primaryPRContent = new PairedResult(inputPrimary);
+      graphDefault.loadContent(primaryPRContent);
+      document.querySelector(`.${styles.pairedBoxGroup}`)
+        .setAttribute("clip-path", 'Dummy-"variable"');
+      const clipId = document.querySelector(`.${styles.pairedBoxGroup}`).getAttribute('clip-path');
+      expect(clipId).toBe('Dummy-"variable"')
+      expect(
+        clipId.replace(/['"]+/g, '')
+      ).toBe('Dummy-variable')
+    });
+  });
 });

--- a/packages/carbon-graphs/webpack/dev-server.js
+++ b/packages/carbon-graphs/webpack/dev-server.js
@@ -29,7 +29,7 @@ const compiler = webpack({
         test: /\.(js|jsx)$/,
         include: [
           path.join(__dirname, '../', 'src'),
-          path.join(__dirname, '../','../','../', 'dev'),
+          path.join(__dirname, '../', 'dev'),
         ],
         use: jsOptions('DEV'),
       },


### PR DESCRIPTION

### Summary
1. Made changes in order to make terra-graphs work in Internet Explorer.
2. The connecting line does not go away for paired results when toggled off in IE. The line would disappear when either High or Low is toggled off in Chrome but not working as expected in IE. Changes made accordingly in this PR to fix the above issue.

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #20 

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-graphs-deployed-pr-45.herokuapp.com/ -->
https://terra-graphs-deployed-pr-#.herokuapp.com/

### Screenshots

**Terra-Graphs in Internet Explorer.**

**Before**

![image](https://user-images.githubusercontent.com/63670637/102122218-cc1d4f00-3e0a-11eb-866d-d4ee82f365d6.png)

**After**

![image](https://user-images.githubusercontent.com/63670637/102121505-b0657900-3e09-11eb-80d3-8faccb992e89.png)


**Paired result graph in Internet Explorer when high is toggled:**

**Before:**

![image](https://user-images.githubusercontent.com/63670637/102121807-2cf85780-3e0a-11eb-9f56-c09b25e81a48.png)

**After:**

![image](https://user-images.githubusercontent.com/63670637/102122353-f7a03980-3e0a-11eb-9e75-2f9b2c015138.png)


<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
@cerner/carbon
