### PR TITLE
Fix: 79 - Updated Y-axis label width to be static

### DIFF
--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated Y-axis label container width to be static instead of dynamic.
+
 ## 2.16.2 - (February 23, 2021)
 
 * Added

--- a/packages/carbon-graphs/src/js/helpers/axis.js
+++ b/packages/carbon-graphs/src/js/helpers/axis.js
@@ -1202,11 +1202,7 @@ const calculateAxesLabelSize = (config) => {
       config.axisLabelHeights.x = getAxisLabelHeight(config.axis.x.label);
     }
     if (config.axis.y.label) {
-      config.axisLabelWidths.y = getAxisLabelWidth(
-        config.axis.y.label,
-        constants.Y_AXIS,
-        config,
-      );
+      config.axisLabelWidths.y = constants.DEFAULT_CHARACTER_SVG_ELEMENT_WIDTH;
     }
     if (hasY2Axis(config.axis) && config.axis.y2.label) {
       config.axisLabelWidths.y2 = hasY2Axis(config.axis)

--- a/packages/carbon-graphs/tests/unit/controls/Graph/GraphAxes-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Graph/GraphAxes-spec.js
@@ -544,7 +544,7 @@ describe('Graph - Axes', () => {
               'transform',
             ),
           ).translate[0],
-        ).toBe(50.625);
+        ).toBe(67.125);
       });
     });
   });

--- a/packages/carbon-graphs/tests/unit/controls/Graph/GraphPanning-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Graph/GraphPanning-spec.js
@@ -30,8 +30,16 @@ import utils from '../../../../src/js/helpers/utils';
 describe('Graph - Panning', () => {
   let graph = null;
   let graphContainer;
+  let consolewarn;
+
   beforeAll(() => {
     loadCustomJasmineMatcher();
+    // to supress warnings
+    consolewarn = console.warn;
+    console.warn = () => {};
+  });
+  afterAll(() => {
+    console.warn = consolewarn;
   });
   beforeEach(() => {
     graphContainer = document.createElement('div');
@@ -156,7 +164,7 @@ describe('Graph - Panning', () => {
             'transform',
           ),
         ).translate[0],
-      ).toBeCloserTo(50);
+      ).toBeCloserTo(68);
       const panData = {
         key: 'uid_1',
         values: [{
@@ -288,7 +296,7 @@ describe('Graph - Panning', () => {
       const regionElementAfterPanning = fetchElementByClass(styles.contentContainer);
       triggerEvent(window, 'resize', () => {
         expect(regionElementAfterPanning.getAttribute('x'))
-          .toBeGreaterThan(containerX);
+          .toEqual(containerX);
         done();
       });
     });


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
This code change updates the logic for the y-axis container generation to be static instead of dynamic.

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #79 

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-graphs-deployed-pr-45.herokuapp.com/ -->
https://terra-graphs-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->
Before:
<img width="386" alt="CleanShot 2021-03-09 at 11 29 46@2x" src="https://user-images.githubusercontent.com/38024451/110512450-d463ee00-80ca-11eb-8cce-c77954165597.png">

After:
<img width="508" alt="CleanShot 2021-03-09 at 11 30 26@2x" src="https://user-images.githubusercontent.com/38024451/110512482-db8afc00-80ca-11eb-8f54-973b1083187b.png">


<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
@cerner/carbon
