### PR TITLE
Chore: remove warnings from unit tests

### DIFF
--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated panning unit tests to supress warnings.
+
 ## 2.16.2 - (February 23, 2021)
 
 * Added

--- a/packages/carbon-graphs/tests/unit/controls/Bar/BarPanning-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Bar/BarPanning-spec.js
@@ -25,8 +25,16 @@ import errors from '../../../../src/js/helpers/errors';
 describe('Bar - Panning', () => {
   let graphDefault = null;
   let barGraphContainer;
+  let consolewarn;
+
   beforeAll(() => {
     loadCustomJasmineMatcher();
+    // to supress warnings
+    consolewarn = console.warn;
+    console.warn = () => {};
+  });
+  afterAll(() => {
+    console.warn = consolewarn;
   });
   beforeEach(() => {
     barGraphContainer = document.createElement('div');

--- a/packages/carbon-graphs/tests/unit/controls/Bar/BarPanningMultipleDatasets-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Bar/BarPanningMultipleDatasets-spec.js
@@ -25,8 +25,16 @@ import errors from '../../../../src/js/helpers/errors';
 describe('Bar - Panning', () => {
   let graphDefault = null;
   let barGraphContainer;
+  let consolewarn;
+
   beforeAll(() => {
     loadCustomJasmineMatcher();
+    // to supress warnings
+    consolewarn = console.warn;
+    console.warn = () => {};
+  });
+  afterAll(() => {
+    console.warn = consolewarn;
   });
   beforeEach(() => {
     barGraphContainer = document.createElement('div');

--- a/packages/carbon-graphs/tests/unit/controls/Gantt/GanttPanning-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Gantt/GanttPanning-spec.js
@@ -28,6 +28,8 @@ import {
 describe('Panning', () => {
   let gantt = null;
   let ganttChartContainer;
+  let consolewarn;
+
   beforeEach(() => {
     ganttChartContainer = document.createElement('div');
     ganttChartContainer.id = 'testCarbonGantt';
@@ -37,6 +39,14 @@ describe('Panning', () => {
     );
     ganttChartContainer.setAttribute('class', 'carbon-test-class');
     document.body.appendChild(ganttChartContainer);
+  });
+  beforeAll(() => {
+    // to supress warnings
+    consolewarn = console.warn;
+    console.warn = () => {};
+  });
+  afterAll(() => {
+    console.warn = consolewarn;
   });
   afterEach(() => {
     document.body.innerHTML = '';

--- a/packages/carbon-graphs/tests/unit/controls/Gantt/GanttPanningMultipleDatasets-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Gantt/GanttPanningMultipleDatasets-spec.js
@@ -28,6 +28,8 @@ import {
 describe('Panning', () => {
   let gantt = null;
   let ganttChartContainer;
+  let consolewarn;
+
   beforeEach(() => {
     ganttChartContainer = document.createElement('div');
     ganttChartContainer.id = 'testCarbonGantt';
@@ -37,6 +39,14 @@ describe('Panning', () => {
     );
     ganttChartContainer.setAttribute('class', 'carbon-test-class');
     document.body.appendChild(ganttChartContainer);
+  });
+  beforeAll(() => {
+    // to supress warnings
+    consolewarn = console.warn;
+    console.warn = () => {};
+  });
+  afterAll(() => {
+    console.warn = consolewarn;
   });
   afterEach(() => {
     document.body.innerHTML = '';

--- a/packages/carbon-graphs/tests/unit/controls/Graph/GraphPanning-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Graph/GraphPanning-spec.js
@@ -30,8 +30,16 @@ import utils from '../../../../src/js/helpers/utils';
 describe('Graph - Panning', () => {
   let graph = null;
   let graphContainer;
+  let consolewarn;
+
   beforeAll(() => {
     loadCustomJasmineMatcher();
+    // to supress warnings
+    consolewarn = console.warn;
+    console.warn = () => {};
+  });
+  afterAll(() => {
+    console.warn = consolewarn;
   });
   beforeEach(() => {
     graphContainer = document.createElement('div');

--- a/packages/carbon-graphs/tests/unit/controls/Graph/GraphPanningMultipleDatasets-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Graph/GraphPanningMultipleDatasets-spec.js
@@ -24,8 +24,16 @@ import {
 describe('Graph - Panning', () => {
   let graph = null;
   let graphContainer;
+  let consolewarn;
+
   beforeAll(() => {
     loadCustomJasmineMatcher();
+    // to supress warnings
+    consolewarn = console.warn;
+    console.warn = () => {};
+  });
+  afterAll(() => {
+    console.warn = consolewarn;
   });
   beforeEach(() => {
     graphContainer = document.createElement('div');

--- a/packages/carbon-graphs/tests/unit/controls/Line/LinePanning-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Line/LinePanning-spec.js
@@ -24,8 +24,16 @@ import {
 describe('Line - Panning', () => {
   let graphDefault = null;
   let lineGraphContainer;
+  let consolewarn;
+
   beforeAll(() => {
     loadCustomJasmineMatcher();
+    // to supress warnings
+    consolewarn = console.warn;
+    console.warn = () => {};
+  });
+  afterAll(() => {
+    console.warn = consolewarn;
   });
   beforeEach(() => {
     lineGraphContainer = document.createElement('div');

--- a/packages/carbon-graphs/tests/unit/controls/Line/LinePanningMultipleDatasets-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Line/LinePanningMultipleDatasets-spec.js
@@ -24,8 +24,16 @@ import {
 describe('Line - Panning', () => {
   let graphDefault = null;
   let lineGraphContainer;
+  let consolewarn;
+
   beforeAll(() => {
     loadCustomJasmineMatcher();
+    // to supress warnings
+    consolewarn = console.warn;
+    console.warn = () => {};
+  });
+  afterAll(() => {
+    console.warn = consolewarn;
   });
   beforeEach(() => {
     lineGraphContainer = document.createElement('div');

--- a/packages/carbon-graphs/tests/unit/controls/PairedResult/PairedResultPanning-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/PairedResult/PairedResultPanning-spec.js
@@ -25,6 +25,16 @@ import errors from '../../../../src/js/helpers/errors';
 describe('PairedResult', () => {
   let graphDefault = null;
   let pairedResultGraphContainer;
+  let consolewarn;
+
+  beforeAll(() => {
+    // to supress warnings
+    consolewarn = console.warn;
+    console.warn = () => {};
+  });
+  afterAll(() => {
+    console.warn = consolewarn;
+  });
   beforeAll(() => {
     loadCustomJasmineMatcher();
   });

--- a/packages/carbon-graphs/tests/unit/controls/PairedResult/PairedResultPanningMultipleDatasets-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/PairedResult/PairedResultPanningMultipleDatasets-spec.js
@@ -25,8 +25,16 @@ import errors from '../../../../src/js/helpers/errors';
 describe('PairedResult', () => {
   let graphDefault = null;
   let pairedResultGraphContainer;
+  let consolewarn;
+
   beforeAll(() => {
     loadCustomJasmineMatcher();
+    // to supress warnings
+    consolewarn = console.warn;
+    console.warn = () => {};
+  });
+  afterAll(() => {
+    console.warn = consolewarn;
   });
   beforeEach(() => {
     pairedResultGraphContainer = document.createElement('div');

--- a/packages/carbon-graphs/tests/unit/controls/Scatter/ScatterPanning-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Scatter/ScatterPanning-spec.js
@@ -20,6 +20,16 @@ import errors from '../../../../src/js/helpers/errors';
 describe('Scatter - Panning', () => {
   let graphDefault = null;
   let scatterGraphContainer;
+  let consolewarn;
+
+  beforeAll(() => {
+    // to supress warnings
+    consolewarn = console.warn;
+    console.warn = () => {};
+  });
+  afterAll(() => {
+    console.warn = consolewarn;
+  });
   beforeEach(() => {
     scatterGraphContainer = document.createElement('div');
     scatterGraphContainer.id = 'testScatter_carbon';

--- a/packages/carbon-graphs/tests/unit/controls/Scatter/ScatterPanningMultipleDatasets-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Scatter/ScatterPanningMultipleDatasets-spec.js
@@ -20,6 +20,16 @@ import errors from '../../../../src/js/helpers/errors';
 describe('Scatter - Panning', () => {
   let graphDefault = null;
   let scatterGraphContainer;
+  let consolewarn;
+
+  beforeAll(() => {
+    // to supress warnings
+    consolewarn = console.warn;
+    console.warn = () => {};
+  });
+  afterAll(() => {
+    console.warn = consolewarn;
+  });
   beforeEach(() => {
     scatterGraphContainer = document.createElement('div');
     scatterGraphContainer.id = 'testScatter_carbon';

--- a/packages/carbon-graphs/tests/unit/controls/Timeline/TimelinePanning-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Timeline/TimelinePanning-spec.js
@@ -19,6 +19,16 @@ import {
 describe('Panning', () => {
   let timeline = null;
   let TimelineGraphContainer;
+  let consolewarn;
+
+  beforeAll(() => {
+    // to supress warnings
+    consolewarn = console.warn;
+    console.warn = () => {};
+  });
+  afterAll(() => {
+    console.warn = consolewarn;
+  });
   beforeEach(() => {
     TimelineGraphContainer = document.createElement('div');
     TimelineGraphContainer.id = 'testCarbonTimeline';

--- a/packages/carbon-graphs/tests/unit/controls/Timeline/TimelinePanningMultipleDatasets-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Timeline/TimelinePanningMultipleDatasets-spec.js
@@ -19,6 +19,16 @@ import {
 describe('Panning', () => {
   let timeline = null;
   let TimelineGraphContainer;
+  let consolewarn;
+
+  beforeAll(() => {
+    // to supress warnings
+    consolewarn = console.warn;
+    console.warn = () => {};
+  });
+  afterAll(() => {
+    console.warn = consolewarn;
+  });
   beforeEach(() => {
     TimelineGraphContainer = document.createElement('div');
     TimelineGraphContainer.id = 'testCarbonTimeline';


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
Currently, warnings in unit tests add spam to output and bury any failing tests. This PR updates tests so that warnings are suppressed.

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-graphs-deployed-pr-45.herokuapp.com/ -->
https://terra-graphs-deployed-pr-#.herokuapp.com/

### Additional Details
Before:
<img width="1621" alt="CleanShot 2021-03-08 at 19 48 41@2x" src="https://user-images.githubusercontent.com/38024451/110418716-a1cfdc00-805d-11eb-91e0-f9e82a3fbdba.png">


After:

<img width="1418" alt="CleanShot 2021-03-08 at 22 34 01@2x" src="https://user-images.githubusercontent.com/38024451/110419172-6a156400-805e-11eb-8d69-2c5a8068e7db.png">


<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
@cerner/carbon
