### PR TITLE
Timeline graph only works if it is the first/only graph on a page

### DIFF
--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 *Changed 
- * Fixed Timeline graph issue when it is generated as second graph in page.
+ * Fixed rendering of timeline graph when it is rendered below another graph.
  
 ## 2.16.3 - (March 16, 2021)
 

--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+*Changed 
+ * Fixed Timeline graph issue when it is generated as second graph in page.
+ 
 ## 2.16.3 - (March 16, 2021)
 
 * Changed

--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-*Changed 
+* Changed 
  * Fixed rendering of timeline graph when it is rendered below another graph.
  
 ## 2.16.3 - (March 16, 2021)

--- a/packages/carbon-graphs/dev/app.less
+++ b/packages/carbon-graphs/dev/app.less
@@ -6,6 +6,7 @@ body {
 }
 
 .carbon-graph-container,
+.carbon-timeline-container,
 .legend-bindto-container {
     font-size: 0.75rem;
     padding: 3rem 0;

--- a/packages/carbon-graphs/src/js/controls/Timeline/Timeline.js
+++ b/packages/carbon-graphs/src/js/controls/Timeline/Timeline.js
@@ -188,7 +188,7 @@ class Timeline extends Construct {
     const containerSVG = d3
       .select(this.config.bindTo)
       .append('div')
-      .classed(styles.container, true)
+      .classed(styles.timelineContainer, true)
       .style('padding-top', this.config.removeContainerPadding && 0)
       .style('padding-bottom', this.config.removeContainerPadding && 0);
     this.svg = containerSVG
@@ -204,15 +204,14 @@ class Timeline extends Construct {
       );
     createDefs(this.config, this.svg);
     createAxes(this.axis, this.scale, this.config, this.svg);
-    const ticks = document.getElementsByClassName('tick');
+    const ticks = document.querySelector(`.${ styles.timelineContainer }`).querySelectorAll('.tick');
     const firstTick = ticks[0].getBoundingClientRect().width;
     const lastTick = ticks[ticks.length - 1].getBoundingClientRect().width;
     const xAxis = document
-      .getElementsByClassName('carbon-axis carbon-axis-x')[0]
-      .getBoundingClientRect().width;
+      .querySelector(`.${ styles.timelineContainer }`).querySelector('.carbon-axis.carbon-axis-x').getBoundingClientRect().width;
     if (xAxis + firstTick / 2 + lastTick / 2 > this.config.canvasWidth) {
-      d3RemoveElement(this.graphContainer, 'defs');
-      d3RemoveElement(this.graphContainer, `.${styles.axisX}`);
+      d3.select(`.${ styles.timelineContainer }`).select('defs').remove();
+      d3.select(`.${ styles.timelineContainer }`).select(`.${styles.axisX}`).remove();
       this.config.padding.left = firstTick / 2;
       this.config.padding.right = lastTick / 2;
       createDefs(this.config, this.svg);
@@ -365,7 +364,7 @@ class Timeline extends Construct {
   destroy() {
     detachEventHandlers(this);
     d3RemoveElement(this.graphContainer, `.${styles.canvas}`);
-    d3RemoveElement(this.graphContainer, `.${styles.container}`);
+    d3RemoveElement(this.graphContainer, `.${styles.timelineContainer}`);
     initConfig(this);
     return this;
   }

--- a/packages/carbon-graphs/src/js/helpers/styles.js
+++ b/packages/carbon-graphs/src/js/helpers/styles.js
@@ -9,6 +9,7 @@
  */
 export default {
   container: 'carbon-graph-container',
+  timelineContainer: 'carbon-timeline-container',
   canvas: 'carbon-graph-canvas',
   canvasXAxis: 'carbon-x-axis-canvas',
   axis: 'carbon-axis',

--- a/packages/carbon-graphs/src/less/core.less
+++ b/packages/carbon-graphs/src/less/core.less
@@ -12,7 +12,8 @@ svg:not(:root) {
     display: inline-block;
 }
 
-.carbon-graph-container {
+.carbon-graph-container,
+.carbon-timeline-container {
     display: block;
     color: @dark;
     padding-bottom: 0.8333rem;

--- a/packages/carbon-graphs/src/less/core.less
+++ b/packages/carbon-graphs/src/less/core.less
@@ -20,6 +20,14 @@ svg:not(:root) {
     width: 100%;
 }
 
+.carbon-timeline-container {
+    display: block;
+    color: @dark;
+    padding-bottom: 0.8333rem;
+    padding-top: 0.8333rem;
+    width: 100%;
+}
+
 .carbon-graph-canvas {
     display: block;
     overflow-x: hidden;

--- a/packages/carbon-graphs/tests/unit/controls/Timeline/Timeline-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Timeline/Timeline-spec.js
@@ -536,14 +536,14 @@ describe('Timeline', () => {
       expect(graphElem).not.toBeNull();
       expect(graphElem.children[0].nodeName).toBe('DIV');
       expect(graphElem.children[0].getAttribute('class')).toBe(
-        styles.container,
+        styles.timelineContainer,
       );
     });
     it('Creates elements in order - with showLegend', () => {
       timeline.destroy();
       timeline = new Timeline(getAxes(axisJSON));
-      const canvas = fetchElementByClass(styles.container).childNodes[0];
-      const legend = fetchElementByClass(styles.container).childNodes[1];
+      const canvas = fetchElementByClass(styles.timelineContainer).childNodes[0];
+      const legend = fetchElementByClass(styles.timelineContainer).childNodes[1];
       expect(canvas).not.toBeNull();
       expect(canvas.getAttribute('class')).toBe(styles.canvas);
       expect(canvas.nodeName).toBe('svg');
@@ -560,8 +560,8 @@ describe('Timeline', () => {
           ...getAxes(axisJSON),
         }),
       );
-      const canvas = fetchElementByClass(styles.container).childNodes[0];
-      const legend = fetchElementByClass(styles.container).childNodes[1];
+      const canvas = fetchElementByClass(styles.timelineContainer).childNodes[0];
+      const legend = fetchElementByClass(styles.timelineContainer).childNodes[1];
       expect(canvas).not.toBeNull();
       expect(canvas.getAttribute('class')).toBe(styles.canvas);
       expect(canvas.nodeName).toBe('svg');
@@ -595,7 +595,7 @@ describe('Timeline', () => {
       expect(labelElement.classList).toContain(styles.axisLabelX);
     });
     it('Creates the canvas svg', () => {
-      const canvas = fetchElementByClass(styles.container).firstChild;
+      const canvas = fetchElementByClass(styles.timelineContainer).firstChild;
       expect(canvas).not.toBeNull();
       expect(canvas.nodeName).toBe('svg');
       expect(canvas.getAttribute('class')).toBe(styles.canvas);
@@ -810,7 +810,7 @@ describe('Timeline', () => {
         const input = utils.deepClone(getAxes(axisJSON));
         input.bindLegendTo = '#timelineLegendContainer';
         timeline = new Timeline(input);
-        const container = fetchElementByClass(styles.container);
+        const container = fetchElementByClass(styles.timelineContainer);
         const parentContainer = fetchElementByClass(
           'carbon-test-class',
         );
@@ -827,7 +827,7 @@ describe('Timeline', () => {
         ).toEqual('legend-container');
         expect(
           parentContainer.childNodes[1].getAttribute('class'),
-        ).toEqual(styles.container);
+        ).toEqual(styles.timelineContainer);
       });
       it('Shows legend when enabled', () => {
         timeline.destroy();
@@ -903,7 +903,7 @@ describe('Timeline', () => {
       expect(fetchElementByClass(styles.legend)).toBeNull();
     });
     it('Removes the container content', () => {
-      expect(fetchElementByClass(styles.container)).toBeNull();
+      expect(fetchElementByClass(styles.timelineContainer)).toBeNull();
     });
     it('Resets the API objects', () => {
       expect(timeline.config).toEqual({

--- a/packages/carbon-graphs/tests/unit/controls/Timeline/TimelineLoad-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Timeline/TimelineLoad-spec.js
@@ -28,6 +28,13 @@ import {
   secondaryValuesJSON,
   valuesJSON,
 } from './helpers';
+import utils from '../../../../src/js/helpers/utils';
+import Gantt from '../../../../src/js/controls/Gantt';
+import {
+  axisJSON as ganttAxisJSON,
+  getData as ganttGetData,
+} from '../Gantt/helpers';
+import { getCurrentTransform, getSVGAnimatedTransformList } from '../../../../src/js/helpers/transformUtils';
 
 describe('Timeline - Load', () => {
   let input;
@@ -754,6 +761,35 @@ describe('Timeline - Load', () => {
           .querySelector(`.${styles.timelineContentGroup}`)
           .getAttribute('aria-describedby'),
       ).toEqual(inputPrimary.key);
+    });
+  });
+  describe('When timeline is created as second graph in page', () => {
+    it('should render graph from right point', () => {
+      timeline.destroy();
+      let gantt = null;
+      let ganttChartContainer = null;
+      const primaryContent = ganttGetData();
+      ganttChartContainer = document.createElement('div');
+      ganttChartContainer.id = 'testCarbonGantt';
+      ganttChartContainer.setAttribute(
+        'style',
+        'width: 1024px; height: 400px;',
+      );
+      ganttChartContainer.setAttribute('class', 'carbon-test-class');
+      document.body.appendChild(ganttChartContainer);
+      gantt = new Gantt(getAxes(ganttAxisJSON));
+      gantt.loadContent(primaryContent);
+
+      timeline = new Timeline(getAxes(axisJSON));
+      const inputPrimary = getData(valuesJSON, false, false);
+      timeline.loadContent(inputPrimary);
+
+      const axisPath = document.querySelector(`.${styles.timelineContainer}`).querySelector(`.${styles.axis}.${styles.axisX}`);
+      expect(
+        getSVGAnimatedTransformList(
+          getCurrentTransform(axisPath),
+        ).translate[0],
+      ).toBe(30);
     });
   });
 });

--- a/packages/carbon-graphs/tests/unit/controls/Timeline/TimelineLoad-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Timeline/TimelineLoad-spec.js
@@ -28,7 +28,6 @@ import {
   secondaryValuesJSON,
   valuesJSON,
 } from './helpers';
-import utils from '../../../../src/js/helpers/utils';
 import Gantt from '../../../../src/js/controls/Gantt';
 import {
   axisJSON as ganttAxisJSON,

--- a/packages/carbon-graphs/tests/unit/controls/Timeline/TimelineLoad-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Timeline/TimelineLoad-spec.js
@@ -763,7 +763,7 @@ describe('Timeline - Load', () => {
     });
   });
   describe('When timeline is created as second graph in page', () => {
-    it('should render graph from right point', () => {
+    it('should render graph from correct point', () => {
       timeline.destroy();
       let gantt = null;
       let ganttChartContainer = null;


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
- Timeline graph only works if it is the first/only graph on a page. Changed the way the timeline graph access the ticks to fix this issue.
<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #84 

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-graphs-deployed-pr-45.herokuapp.com/ -->
https://terra-graphs-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->
- Wrote test case by reproducing the issue and testing the translate position of timeline graph.

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Screenshots:

### Before:

![image](https://user-images.githubusercontent.com/63670637/113912520-d5a73a00-97a0-11eb-93ff-a09dd0a03214.png)

### After:

![image](https://user-images.githubusercontent.com/63670637/113912590-ee175480-97a0-11eb-8069-cca64f2f7104.png)


Thank you for contributing to Terra.
@cerner/terra
@cerner/carbon
