### PR TITLE
Fixed Y-axis and y2-axis icons not updating during reflow

### DIFF
--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Fixed Y-axis and y2-axis icons not updating during reflow.
+  
 ## 2.16.3 - (March 16, 2021)
 
 * Changed

--- a/packages/carbon-graphs/src/js/controls/Bar/Bar.js
+++ b/packages/carbon-graphs/src/js/controls/Bar/Bar.js
@@ -260,7 +260,8 @@ class Bar extends GraphContent {
       );
     } else if (graph.config.axis.y2.show) {
       /* If data belongs to yAxis and shape associated with data id in yAxis is null then prepareLabelShapeItem method gets executed to add shape in yAxis
-       else if data belongs to y2Axis and shape associated with data id in y2Axis is null then prepareLabelShapeItem method gets executed to add shapes in y2Axes. */      if (this.config.yAxis === 'y' && (document.querySelector('.carbon-y-axis-label-shape-container').querySelector(`svg[aria-describedby="${graphData.key}"]`) == null)) {
+       else if data belongs to y2Axis and shape associated with data id in y2Axis is null then prepareLabelShapeItem method gets executed to add shapes in y2Axes. */
+      if (this.config.yAxis === 'y' && (document.querySelector('.carbon-y-axis-label-shape-container').querySelector(`svg[aria-describedby="${graphData.key}"]`) == null)) {
         prepareLabelShapeItem(
           graph.config,
           this.dataTarget,

--- a/packages/carbon-graphs/src/js/controls/Bar/Bar.js
+++ b/packages/carbon-graphs/src/js/controls/Bar/Bar.js
@@ -4,6 +4,7 @@ import { GraphContent } from '../../core';
 import { getDefaultValue } from '../../core/BaseConfig';
 import constants from '../../helpers/constants';
 import {
+  addShapesDuringFlow,
   prepareLabelShapeItem,
   removeLabelShapeItem,
 } from '../../helpers/label';
@@ -259,21 +260,7 @@ class Bar extends GraphContent {
         graph.config,
       );
     } else if (graph.config.axis.y2.show) {
-      /* If data belongs to yAxis and shape associated with data id in yAxis is null then prepareLabelShapeItem method gets executed to add shape in yAxis
-       else if data belongs to y2Axis and shape associated with data id in y2Axis is null then prepareLabelShapeItem method gets executed to add shapes in y2Axes. */
-      if (this.config.yAxis === 'y' && (graph.svg.select(`.${styles.axisLabelYShapeContainer} svg[aria-describedby="${graphData.key}"]`).empty())) {
-        prepareLabelShapeItem(
-          graph.config,
-          this.dataTarget,
-          graph.axesLabelShapeGroup[this.config.yAxis],
-        );
-      } else if (this.config.yAxis === 'y2' && (graph.svg.select(`.${styles.axisLabelY2ShapeContainer} svg[aria-describedby="${graphData.key}"]`).empty())) {
-        prepareLabelShapeItem(
-          graph.config,
-          this.dataTarget,
-          graph.axesLabelShapeGroup[this.config.yAxis],
-        );
-      }
+      addShapesDuringFlow(graph, graphData, this);
     }
     scaleBandAxis(this.bandScale, graph.config, graph.content);
     const barSelectionGroup = graph.svg

--- a/packages/carbon-graphs/src/js/controls/Bar/Bar.js
+++ b/packages/carbon-graphs/src/js/controls/Bar/Bar.js
@@ -4,9 +4,9 @@ import { GraphContent } from '../../core';
 import { getDefaultValue } from '../../core/BaseConfig';
 import constants from '../../helpers/constants';
 import {
-  addShapesDuringFlow,
   prepareLabelShapeItem,
-  removeLabelShapeItem, updateShapesDuringReflow,
+  removeLabelShapeItem,
+  updateShapesDuringReflow,
 } from '../../helpers/label';
 import { removeLegendItem, reflowLegend } from '../../helpers/legend';
 import styles from '../../helpers/styles';

--- a/packages/carbon-graphs/src/js/controls/Bar/Bar.js
+++ b/packages/carbon-graphs/src/js/controls/Bar/Bar.js
@@ -258,6 +258,22 @@ class Bar extends GraphContent {
         this.dataTarget,
         graph.config,
       );
+    } else if (graph.config.axis.y2.show) {
+      /* If data belongs to yAxis and shapes present in yAxis is null then prepareLabelShapeItem method gets executed to add shapes in yAxis
+       else if data belongs to y2Axis and shapes present in yAxis is null then prepareLabelShapeItem method gets executed to add shapes in y2Axes. */
+      if (this.config.yAxis === 'y' && (document.querySelector('.carbon-y-axis-label-shape-container svg') == null)) {
+        prepareLabelShapeItem(
+          graph.config,
+          this.dataTarget,
+          graph.axesLabelShapeGroup[this.config.yAxis],
+        );
+      } else if (this.config.yAxis === 'y2' && (document.querySelector('.carbon-y2-axis-label-shape-container svg') == null)) {
+        prepareLabelShapeItem(
+          graph.config,
+          this.dataTarget,
+          graph.axesLabelShapeGroup[this.config.yAxis],
+        );
+      }
     }
     scaleBandAxis(this.bandScale, graph.config, graph.content);
     const barSelectionGroup = graph.svg

--- a/packages/carbon-graphs/src/js/controls/Bar/Bar.js
+++ b/packages/carbon-graphs/src/js/controls/Bar/Bar.js
@@ -259,15 +259,14 @@ class Bar extends GraphContent {
         graph.config,
       );
     } else if (graph.config.axis.y2.show) {
-      /* If data belongs to yAxis and shapes present in yAxis is null then prepareLabelShapeItem method gets executed to add shapes in yAxis
-       else if data belongs to y2Axis and shapes present in yAxis is null then prepareLabelShapeItem method gets executed to add shapes in y2Axes. */
-      if (this.config.yAxis === 'y' && (document.querySelector('.carbon-y-axis-label-shape-container svg') == null)) {
+      /* If data belongs to yAxis and shape associated with data id in yAxis is null then prepareLabelShapeItem method gets executed to add shape in yAxis
+       else if data belongs to y2Axis and shape associated with data id in y2Axis is null then prepareLabelShapeItem method gets executed to add shapes in y2Axes. */      if (this.config.yAxis === 'y' && (document.querySelector('.carbon-y-axis-label-shape-container').querySelector(`svg[aria-describedby="${graphData.key}"]`) == null)) {
         prepareLabelShapeItem(
           graph.config,
           this.dataTarget,
           graph.axesLabelShapeGroup[this.config.yAxis],
         );
-      } else if (this.config.yAxis === 'y2' && (document.querySelector('.carbon-y2-axis-label-shape-container svg') == null)) {
+      } else if (this.config.yAxis === 'y2' && (document.querySelector('.carbon-y2-axis-label-shape-container').querySelector(`svg[aria-describedby="${graphData.key}"]`) == null)) {
         prepareLabelShapeItem(
           graph.config,
           this.dataTarget,

--- a/packages/carbon-graphs/src/js/controls/Bar/Bar.js
+++ b/packages/carbon-graphs/src/js/controls/Bar/Bar.js
@@ -6,7 +6,7 @@ import constants from '../../helpers/constants';
 import {
   addShapesDuringFlow,
   prepareLabelShapeItem,
-  removeLabelShapeItem,
+  removeLabelShapeItem, updateShapesDuringReflow,
 } from '../../helpers/label';
 import { removeLegendItem, reflowLegend } from '../../helpers/legend';
 import styles from '../../helpers/styles';
@@ -253,15 +253,8 @@ class Bar extends GraphContent {
       x: d,
       valueSubsetArray: [],
     }));
-    if (utils.isEmpty(graphData.values)) {
-      removeLabelShapeItem(
-        graph.axesLabelShapeGroup[this.config.yAxis],
-        this.dataTarget,
-        graph.config,
-      );
-    } else if (graph.config.axis.y2.show) {
-      addShapesDuringFlow(graph, graphData, this);
-    }
+
+    updateShapesDuringReflow(graph, graphData, this);
     scaleBandAxis(this.bandScale, graph.config, graph.content);
     const barSelectionGroup = graph.svg
       .select(`.${styles.barSelectionGroup}`)

--- a/packages/carbon-graphs/src/js/controls/Bar/Bar.js
+++ b/packages/carbon-graphs/src/js/controls/Bar/Bar.js
@@ -261,13 +261,13 @@ class Bar extends GraphContent {
     } else if (graph.config.axis.y2.show) {
       /* If data belongs to yAxis and shape associated with data id in yAxis is null then prepareLabelShapeItem method gets executed to add shape in yAxis
        else if data belongs to y2Axis and shape associated with data id in y2Axis is null then prepareLabelShapeItem method gets executed to add shapes in y2Axes. */
-      if (this.config.yAxis === 'y' && (document.querySelector('.carbon-y-axis-label-shape-container').querySelector(`svg[aria-describedby="${graphData.key}"]`) == null)) {
+      if (this.config.yAxis === 'y' && (graph.svg.select(`.${styles.axisLabelYShapeContainer} svg[aria-describedby="${graphData.key}"]`).empty())) {
         prepareLabelShapeItem(
           graph.config,
           this.dataTarget,
           graph.axesLabelShapeGroup[this.config.yAxis],
         );
-      } else if (this.config.yAxis === 'y2' && (document.querySelector('.carbon-y2-axis-label-shape-container').querySelector(`svg[aria-describedby="${graphData.key}"]`) == null)) {
+      } else if (this.config.yAxis === 'y2' && (graph.svg.select(`.${styles.axisLabelY2ShapeContainer} svg[aria-describedby="${graphData.key}"]`).empty())) {
         prepareLabelShapeItem(
           graph.config,
           this.dataTarget,

--- a/packages/carbon-graphs/src/js/controls/Line/Line.js
+++ b/packages/carbon-graphs/src/js/controls/Line/Line.js
@@ -256,7 +256,25 @@ class Line extends GraphContent {
         this.dataTarget,
         graph.config,
       );
+    } else if (graph.config.axis.y2.show) {
+      /* If data belongs to yAxis and shapes present in yAxis is null then prepareLabelShapeItem method gets executed to add shapes in yAxis
+       else if data belongs to y2Axis and shapes present in yAxis is null then prepareLabelShapeItem method gets executed to add shapes in y2Axes. */
+      if (this.config.yAxis === 'y' && (document.querySelector('.carbon-y-axis-label-shape-container svg') == null)) {
+        prepareLabelShapeItem(
+          graph.config,
+          this.dataTarget,
+          graph.axesLabelShapeGroup[this.config.yAxis],
+        );
+      } else if (this.config.yAxis === 'y2' && (document.querySelector('.carbon-y2-axis-label-shape-container svg') == null)) {
+        prepareLabelShapeItem(
+          graph.config,
+          this.dataTarget,
+          graph.axesLabelShapeGroup[this.config.yAxis],
+        );
+      }
     }
+
+
 
     if (graph.config.showShapes) {
       const currentPointsPath = graph.svg

--- a/packages/carbon-graphs/src/js/controls/Line/Line.js
+++ b/packages/carbon-graphs/src/js/controls/Line/Line.js
@@ -259,13 +259,13 @@ class Line extends GraphContent {
     } else if (graph.config.axis.y2.show) {
       /* If data belongs to yAxis and shape associated with data id in yAxis is null then prepareLabelShapeItem method gets executed to add shape in yAxis
        else if data belongs to y2Axis and shape associated with data id in y2Axis is null then prepareLabelShapeItem method gets executed to add shapes in y2Axes. */
-      if (this.config.yAxis === 'y' && (document.querySelector('.carbon-y-axis-label-shape-container').querySelector(`svg[aria-describedby="${graphData.key}"]`) == null)) {
+      if (this.config.yAxis === 'y' && (graph.svg.select(`.${styles.axisLabelYShapeContainer} svg[aria-describedby="${graphData.key}"]`).empty())) {
         prepareLabelShapeItem(
           graph.config,
           this.dataTarget,
           graph.axesLabelShapeGroup[this.config.yAxis],
         );
-      } else if (this.config.yAxis === 'y2' && (document.querySelector('.carbon-y2-axis-label-shape-container').querySelector(`svg[aria-describedby="${graphData.key}"]`) == null)) {
+      } else if (this.config.yAxis === 'y2' && (graph.svg.select(`.${styles.axisLabelY2ShapeContainer} svg[aria-describedby="${graphData.key}"]`).empty())) {
         prepareLabelShapeItem(
           graph.config,
           this.dataTarget,

--- a/packages/carbon-graphs/src/js/controls/Line/Line.js
+++ b/packages/carbon-graphs/src/js/controls/Line/Line.js
@@ -6,6 +6,7 @@ import constants from '../../helpers/constants';
 import {
   prepareLabelShapeItem,
   removeLabelShapeItem,
+  addShapesDuringFlow,
 } from '../../helpers/label';
 import { removeLegendItem, reflowLegend } from '../../helpers/legend';
 import {
@@ -257,21 +258,7 @@ class Line extends GraphContent {
         graph.config,
       );
     } else if (graph.config.axis.y2.show) {
-      /* If data belongs to yAxis and shape associated with data id in yAxis is null then prepareLabelShapeItem method gets executed to add shape in yAxis
-       else if data belongs to y2Axis and shape associated with data id in y2Axis is null then prepareLabelShapeItem method gets executed to add shapes in y2Axes. */
-      if (this.config.yAxis === 'y' && (graph.svg.select(`.${styles.axisLabelYShapeContainer} svg[aria-describedby="${graphData.key}"]`).empty())) {
-        prepareLabelShapeItem(
-          graph.config,
-          this.dataTarget,
-          graph.axesLabelShapeGroup[this.config.yAxis],
-        );
-      } else if (this.config.yAxis === 'y2' && (graph.svg.select(`.${styles.axisLabelY2ShapeContainer} svg[aria-describedby="${graphData.key}"]`).empty())) {
-        prepareLabelShapeItem(
-          graph.config,
-          this.dataTarget,
-          graph.axesLabelShapeGroup[this.config.yAxis],
-        );
-      }
+      addShapesDuringFlow(graph, graphData, this);
     }
 
     if (graph.config.showShapes) {

--- a/packages/carbon-graphs/src/js/controls/Line/Line.js
+++ b/packages/carbon-graphs/src/js/controls/Line/Line.js
@@ -257,15 +257,15 @@ class Line extends GraphContent {
         graph.config,
       );
     } else if (graph.config.axis.y2.show) {
-      /* If data belongs to yAxis and shapes present in yAxis is null then prepareLabelShapeItem method gets executed to add shapes in yAxis
-       else if data belongs to y2Axis and shapes present in yAxis is null then prepareLabelShapeItem method gets executed to add shapes in y2Axes. */
-      if (this.config.yAxis === 'y' && (document.querySelector('.carbon-y-axis-label-shape-container svg') == null)) {
+      /* If data belongs to yAxis and shape associated with data id in yAxis is null then prepareLabelShapeItem method gets executed to add shape in yAxis
+       else if data belongs to y2Axis and shape associated with data id in y2Axis is null then prepareLabelShapeItem method gets executed to add shapes in y2Axes. */
+      if (this.config.yAxis === 'y' && (document.querySelector('.carbon-y-axis-label-shape-container').querySelector(`svg[aria-describedby="${graphData.key}"]`) == null)) {
         prepareLabelShapeItem(
           graph.config,
           this.dataTarget,
           graph.axesLabelShapeGroup[this.config.yAxis],
         );
-      } else if (this.config.yAxis === 'y2' && (document.querySelector('.carbon-y2-axis-label-shape-container svg') == null)) {
+      } else if (this.config.yAxis === 'y2' && (document.querySelector('.carbon-y2-axis-label-shape-container').querySelector(`svg[aria-describedby="${graphData.key}"]`) == null)) {
         prepareLabelShapeItem(
           graph.config,
           this.dataTarget,
@@ -273,8 +273,6 @@ class Line extends GraphContent {
         );
       }
     }
-
-
 
     if (graph.config.showShapes) {
       const currentPointsPath = graph.svg

--- a/packages/carbon-graphs/src/js/controls/Line/Line.js
+++ b/packages/carbon-graphs/src/js/controls/Line/Line.js
@@ -6,7 +6,7 @@ import constants from '../../helpers/constants';
 import {
   prepareLabelShapeItem,
   removeLabelShapeItem,
-  addShapesDuringFlow,
+  updateShapesDuringReflow,
 } from '../../helpers/label';
 import { removeLegendItem, reflowLegend } from '../../helpers/legend';
 import {
@@ -251,16 +251,7 @@ class Line extends GraphContent {
     drawDataLines(graph.scale, graph.config, lineSVG.enter());
     lineSVG.exit().remove();
 
-    if (utils.isEmpty(graphData.values)) {
-      removeLabelShapeItem(
-        graph.axesLabelShapeGroup[this.config.yAxis],
-        this.dataTarget,
-        graph.config,
-      );
-    } else if (graph.config.axis.y2.show) {
-      addShapesDuringFlow(graph, graphData, this);
-    }
-
+    updateShapesDuringReflow(graph, graphData, this);
     if (graph.config.showShapes) {
       const currentPointsPath = graph.svg
         .select(`g[aria-describedby="${graphData.key}"]`)

--- a/packages/carbon-graphs/src/js/controls/PairedResult/PairedResult.js
+++ b/packages/carbon-graphs/src/js/controls/PairedResult/PairedResult.js
@@ -332,7 +332,7 @@ class PairedResult extends GraphContent {
        else if data belongs to y2Axis and shape associated with data id in y2Axis is null then prepareLabelShapeItem method gets executed to add shapes in y2Axes. */
       if (this.config.yAxis === 'y') {
         iterateOnPairType((type) => {
-          if (document.querySelector('.carbon-y-axis-label-shape-container').querySelector(`svg[aria-describedby="${graphData.key}_${type}"]`) == null) {
+          if ((graph.svg.select(`.${styles.axisLabelYShapeContainer} svg[aria-describedby="${graphData.key}_${type}"]`).empty())) {
             prepareLabelShapeItem(
               graph.config,
               {
@@ -346,9 +346,9 @@ class PairedResult extends GraphContent {
             );
           }
         });
-      } else if (this.config.yAxis === 'y2' && (document.querySelector('.carbon-y2-axis-label-shape-container').querySelector(`svg[aria-describedby="${graphData.key}"]`) == null)) {
+      } else if (this.config.yAxis === 'y2') {
         iterateOnPairType((type) => {
-          if (document.querySelector('.carbon-y2-axis-label-shape-container').querySelector(`svg[aria-describedby="${graphData.key}_${type}"]`) == null) {
+          if ((graph.svg.select(`.${styles.axisLabelY2ShapeContainer} svg[aria-describedby="${graphData.key}_${type}"]`).empty())) {
             prepareLabelShapeItem(
               graph.config,
               {

--- a/packages/carbon-graphs/src/js/controls/PairedResult/PairedResult.js
+++ b/packages/carbon-graphs/src/js/controls/PairedResult/PairedResult.js
@@ -328,35 +328,39 @@ class PairedResult extends GraphContent {
         );
       });
     } else if (graph.config.axis.y2.show) {
-      /* If data belongs to yAxis and shapes present in yAxis is null then prepareLabelShapeItem method gets executed to add shapes in yAxis
-       else if data belongs to y2Axis and shapes present in yAxis is null then prepareLabelShapeItem method gets executed to add shapes in y2Axes. */
-      if (this.config.yAxis === 'y' && (document.querySelector('.carbon-y-axis-label-shape-container svg') == null)) {
+      /* If data belongs to yAxis and shape associated with data id in yAxis is null then prepareLabelShapeItem method gets executed to add shape in yAxis
+       else if data belongs to y2Axis and shape associated with data id in y2Axis is null then prepareLabelShapeItem method gets executed to add shapes in y2Axes. */
+      if (this.config.yAxis === 'y') {
         iterateOnPairType((type) => {
-          prepareLabelShapeItem(
-            graph.config,
-            {
-              key: `${this.dataTarget.key}_${type}`,
-              label: getValue(this.dataTarget.label, type),
-              color: getValue(this.dataTarget.color, type),
-              shape: getValue(this.dataTarget.shape, type),
-              values: this.dataTarget.values,
-            },
-            graph.axesLabelShapeGroup[this.config.yAxis],
-          );
+          if (document.querySelector('.carbon-y-axis-label-shape-container').querySelector(`svg[aria-describedby="${graphData.key}_${type}"]`) == null) {
+            prepareLabelShapeItem(
+              graph.config,
+              {
+                key: `${this.dataTarget.key}_${type}`,
+                label: getValue(this.dataTarget.label, type),
+                color: getValue(this.dataTarget.color, type),
+                shape: getValue(this.dataTarget.shape, type),
+                values: this.dataTarget.values,
+              },
+              graph.axesLabelShapeGroup[this.config.yAxis],
+            );
+          }
         });
-      } else if (this.config.yAxis === 'y2' && (document.querySelector('.carbon-y2-axis-label-shape-container svg') == null)) {
+      } else if (this.config.yAxis === 'y2' && (document.querySelector('.carbon-y2-axis-label-shape-container').querySelector(`svg[aria-describedby="${graphData.key}"]`) == null)) {
         iterateOnPairType((type) => {
-          prepareLabelShapeItem(
-            graph.config,
-            {
-              key: `${this.dataTarget.key}_${type}`,
-              label: getValue(this.dataTarget.label, type),
-              color: getValue(this.dataTarget.color, type),
-              shape: getValue(this.dataTarget.shape, type),
-              values: this.dataTarget.values,
-            },
-            graph.axesLabelShapeGroup[this.config.yAxis],
-          );
+          if (document.querySelector('.carbon-y2-axis-label-shape-container').querySelector(`svg[aria-describedby="${graphData.key}_${type}"]`) == null) {
+            prepareLabelShapeItem(
+              graph.config,
+              {
+                key: `${this.dataTarget.key}_${type}`,
+                label: getValue(this.dataTarget.label, type),
+                color: getValue(this.dataTarget.color, type),
+                shape: getValue(this.dataTarget.shape, type),
+                values: this.dataTarget.values,
+              },
+              graph.axesLabelShapeGroup[this.config.yAxis],
+            );
+          }
         });
       }
     }

--- a/packages/carbon-graphs/src/js/controls/PairedResult/PairedResult.js
+++ b/packages/carbon-graphs/src/js/controls/PairedResult/PairedResult.js
@@ -316,53 +316,30 @@ class PairedResult extends GraphContent {
         }
       }
     });
-    if (utils.isEmpty(graphData.values)) {
+    iterateOnPairType((type) => {
+      const key = `${this.dataTarget.key}_${type}`;
+      removeLabelShapeItem(
+        graph.axesLabelShapeGroup[this.config.yAxis],
+        {
+          key,
+        },
+        graph.config,
+      );
+    });
+    if (!utils.isEmpty(graphData.values)) {
       iterateOnPairType((type) => {
-        const key = `${this.dataTarget.key}_${type}`;
-        removeLabelShapeItem(
-          graph.axesLabelShapeGroup[this.config.yAxis],
-          {
-            key,
-          },
+        prepareLabelShapeItem(
           graph.config,
+          {
+            key: `${this.dataTarget.key}_${type}`,
+            label: getValue(this.dataTarget.label, type),
+            color: getValue(this.dataTarget.color, type),
+            shape: getValue(this.dataTarget.shape, type),
+            values: this.dataTarget.values,
+          },
+          graph.axesLabelShapeGroup[this.config.yAxis],
         );
       });
-    } else if (graph.config.axis.y2.show) {
-      /* If data belongs to yAxis and shape associated with data id in yAxis is null then prepareLabelShapeItem method gets executed to add shape in yAxis
-       else if data belongs to y2Axis and shape associated with data id in y2Axis is null then prepareLabelShapeItem method gets executed to add shapes in y2Axes. */
-      if (this.config.yAxis === 'y') {
-        iterateOnPairType((type) => {
-          if ((graph.svg.select(`.${styles.axisLabelYShapeContainer} svg[aria-describedby="${graphData.key}_${type}"]`).empty())) {
-            prepareLabelShapeItem(
-              graph.config,
-              {
-                key: `${this.dataTarget.key}_${type}`,
-                label: getValue(this.dataTarget.label, type),
-                color: getValue(this.dataTarget.color, type),
-                shape: getValue(this.dataTarget.shape, type),
-                values: this.dataTarget.values,
-              },
-              graph.axesLabelShapeGroup[this.config.yAxis],
-            );
-          }
-        });
-      } else if (this.config.yAxis === 'y2') {
-        iterateOnPairType((type) => {
-          if ((graph.svg.select(`.${styles.axisLabelY2ShapeContainer} svg[aria-describedby="${graphData.key}_${type}"]`).empty())) {
-            prepareLabelShapeItem(
-              graph.config,
-              {
-                key: `${this.dataTarget.key}_${type}`,
-                label: getValue(this.dataTarget.label, type),
-                color: getValue(this.dataTarget.color, type),
-                shape: getValue(this.dataTarget.shape, type),
-                values: this.dataTarget.values,
-              },
-              graph.axesLabelShapeGroup[this.config.yAxis],
-            );
-          }
-        });
-      }
     }
     const internalValuesSubset = getDataPointValues(this.dataTarget);
     graph.svg

--- a/packages/carbon-graphs/src/js/controls/PairedResult/PairedResult.js
+++ b/packages/carbon-graphs/src/js/controls/PairedResult/PairedResult.js
@@ -327,6 +327,38 @@ class PairedResult extends GraphContent {
           graph.config,
         );
       });
+    } else if (graph.config.axis.y2.show) {
+      /* If data belongs to yAxis and shapes present in yAxis is null then prepareLabelShapeItem method gets executed to add shapes in yAxis
+       else if data belongs to y2Axis and shapes present in yAxis is null then prepareLabelShapeItem method gets executed to add shapes in y2Axes. */
+      if (this.config.yAxis === 'y' && (document.querySelector('.carbon-y-axis-label-shape-container svg') == null)) {
+        iterateOnPairType((type) => {
+          prepareLabelShapeItem(
+            graph.config,
+            {
+              key: `${this.dataTarget.key}_${type}`,
+              label: getValue(this.dataTarget.label, type),
+              color: getValue(this.dataTarget.color, type),
+              shape: getValue(this.dataTarget.shape, type),
+              values: this.dataTarget.values,
+            },
+            graph.axesLabelShapeGroup[this.config.yAxis],
+          );
+        });
+      } else if (this.config.yAxis === 'y2' && (document.querySelector('.carbon-y2-axis-label-shape-container svg') == null)) {
+        iterateOnPairType((type) => {
+          prepareLabelShapeItem(
+            graph.config,
+            {
+              key: `${this.dataTarget.key}_${type}`,
+              label: getValue(this.dataTarget.label, type),
+              color: getValue(this.dataTarget.color, type),
+              shape: getValue(this.dataTarget.shape, type),
+              values: this.dataTarget.values,
+            },
+            graph.axesLabelShapeGroup[this.config.yAxis],
+          );
+        });
+      }
     }
     const internalValuesSubset = getDataPointValues(this.dataTarget);
     graph.svg

--- a/packages/carbon-graphs/src/js/controls/Scatter/Scatter.js
+++ b/packages/carbon-graphs/src/js/controls/Scatter/Scatter.js
@@ -236,6 +236,22 @@ class Scatter extends GraphContent {
         this.dataTarget,
         graph.config,
       );
+    } else if (graph.config.axis.y2.show) {
+      /* If data belongs to yAxis and shapes present in yAxis is null then prepareLabelShapeItem method gets executed to add shapes in yAxis
+       else if data belongs to y2Axis and shapes present in yAxis is null then prepareLabelShapeItem method gets executed to add shapes in y2Axes. */
+      if (this.config.yAxis === 'y' && (document.querySelector('.carbon-y-axis-label-shape-container svg') == null)) {
+        prepareLabelShapeItem(
+          graph.config,
+          this.dataTarget,
+          graph.axesLabelShapeGroup[this.config.yAxis],
+        );
+      } else if (this.config.yAxis === 'y2' && (document.querySelector('.carbon-y2-axis-label-shape-container svg') == null)) {
+        prepareLabelShapeItem(
+          graph.config,
+          this.dataTarget,
+          graph.axesLabelShapeGroup[this.config.yAxis],
+        );
+      }
     }
     this.valuesRange = calculateValuesRange(
       this.config.values,

--- a/packages/carbon-graphs/src/js/controls/Scatter/Scatter.js
+++ b/packages/carbon-graphs/src/js/controls/Scatter/Scatter.js
@@ -4,7 +4,7 @@ import { GraphContent } from '../../core';
 import { getDefaultValue } from '../../core/BaseConfig';
 import constants from '../../helpers/constants';
 import {
-  addShapesDuringFlow,
+  updateShapesDuringReflow,
   prepareLabelShapeItem,
   removeLabelShapeItem,
 } from '../../helpers/label';
@@ -231,16 +231,8 @@ class Scatter extends GraphContent {
         ),
       )
       .remove();
-    if (utils.isEmpty(graphData.values)) {
-      removeLabelShapeItem(
-        graph.axesLabelShapeGroup[this.config.yAxis],
-        this.dataTarget,
-        graph.config,
-      );
-    } else if (graph.config.axis.y2.show) {
-      addShapesDuringFlow(graph, graphData, this);
-    }
 
+    updateShapesDuringReflow(graph, graphData, this);
     this.valuesRange = calculateValuesRange(
       this.config.values,
       this.config.yAxis,

--- a/packages/carbon-graphs/src/js/controls/Scatter/Scatter.js
+++ b/packages/carbon-graphs/src/js/controls/Scatter/Scatter.js
@@ -239,13 +239,13 @@ class Scatter extends GraphContent {
     } else if (graph.config.axis.y2.show) {
       /* If data belongs to yAxis and shape associated with data id in yAxis is null then prepareLabelShapeItem method gets executed to add shape in yAxis
        else if data belongs to y2Axis and shape associated with data id in y2Axis is null then prepareLabelShapeItem method gets executed to add shapes in y2Axes. */
-      if (this.config.yAxis === 'y' && (document.querySelector('.carbon-y-axis-label-shape-container').querySelector(`svg[aria-describedby="${graphData.key}"]`) == null)) {
+      if (this.config.yAxis === 'y' && (graph.svg.select(`.${styles.axisLabelYShapeContainer} svg[aria-describedby="${graphData.key}"]`).empty())) {
         prepareLabelShapeItem(
           graph.config,
           this.dataTarget,
           graph.axesLabelShapeGroup[this.config.yAxis],
         );
-      } else if (this.config.yAxis === 'y2' && (document.querySelector('.carbon-y2-axis-label-shape-container').querySelector(`svg[aria-describedby="${graphData.key}"]`) == null)) {
+      } else if (this.config.yAxis === 'y2' && (graph.svg.select(`.${styles.axisLabelY2ShapeContainer} svg[aria-describedby="${graphData.key}"]`).empty())) {
         prepareLabelShapeItem(
           graph.config,
           this.dataTarget,

--- a/packages/carbon-graphs/src/js/controls/Scatter/Scatter.js
+++ b/packages/carbon-graphs/src/js/controls/Scatter/Scatter.js
@@ -4,6 +4,7 @@ import { GraphContent } from '../../core';
 import { getDefaultValue } from '../../core/BaseConfig';
 import constants from '../../helpers/constants';
 import {
+  addShapesDuringFlow,
   prepareLabelShapeItem,
   removeLabelShapeItem,
 } from '../../helpers/label';
@@ -237,22 +238,9 @@ class Scatter extends GraphContent {
         graph.config,
       );
     } else if (graph.config.axis.y2.show) {
-      /* If data belongs to yAxis and shape associated with data id in yAxis is null then prepareLabelShapeItem method gets executed to add shape in yAxis
-       else if data belongs to y2Axis and shape associated with data id in y2Axis is null then prepareLabelShapeItem method gets executed to add shapes in y2Axes. */
-      if (this.config.yAxis === 'y' && (graph.svg.select(`.${styles.axisLabelYShapeContainer} svg[aria-describedby="${graphData.key}"]`).empty())) {
-        prepareLabelShapeItem(
-          graph.config,
-          this.dataTarget,
-          graph.axesLabelShapeGroup[this.config.yAxis],
-        );
-      } else if (this.config.yAxis === 'y2' && (graph.svg.select(`.${styles.axisLabelY2ShapeContainer} svg[aria-describedby="${graphData.key}"]`).empty())) {
-        prepareLabelShapeItem(
-          graph.config,
-          this.dataTarget,
-          graph.axesLabelShapeGroup[this.config.yAxis],
-        );
-      }
+      addShapesDuringFlow(graph, graphData, this);
     }
+
     this.valuesRange = calculateValuesRange(
       this.config.values,
       this.config.yAxis,

--- a/packages/carbon-graphs/src/js/controls/Scatter/Scatter.js
+++ b/packages/carbon-graphs/src/js/controls/Scatter/Scatter.js
@@ -237,15 +237,15 @@ class Scatter extends GraphContent {
         graph.config,
       );
     } else if (graph.config.axis.y2.show) {
-      /* If data belongs to yAxis and shapes present in yAxis is null then prepareLabelShapeItem method gets executed to add shapes in yAxis
-       else if data belongs to y2Axis and shapes present in yAxis is null then prepareLabelShapeItem method gets executed to add shapes in y2Axes. */
-      if (this.config.yAxis === 'y' && (document.querySelector('.carbon-y-axis-label-shape-container svg') == null)) {
+      /* If data belongs to yAxis and shape associated with data id in yAxis is null then prepareLabelShapeItem method gets executed to add shape in yAxis
+       else if data belongs to y2Axis and shape associated with data id in y2Axis is null then prepareLabelShapeItem method gets executed to add shapes in y2Axes. */
+      if (this.config.yAxis === 'y' && (document.querySelector('.carbon-y-axis-label-shape-container').querySelector(`svg[aria-describedby="${graphData.key}"]`) == null)) {
         prepareLabelShapeItem(
           graph.config,
           this.dataTarget,
           graph.axesLabelShapeGroup[this.config.yAxis],
         );
-      } else if (this.config.yAxis === 'y2' && (document.querySelector('.carbon-y2-axis-label-shape-container svg') == null)) {
+      } else if (this.config.yAxis === 'y2' && (document.querySelector('.carbon-y2-axis-label-shape-container').querySelector(`svg[aria-describedby="${graphData.key}"]`) == null)) {
         prepareLabelShapeItem(
           graph.config,
           this.dataTarget,

--- a/packages/carbon-graphs/src/js/helpers/label.js
+++ b/packages/carbon-graphs/src/js/helpers/label.js
@@ -337,23 +337,20 @@ const destroyTooltipDiv = () => {
 };
 
 /**
- * Add shapes to y and y2 axes during reflow.
+ * Update shapes in y and y2 axes during reflow.
  *
  * @private
  * @param {object} graph - Graph instance
  * @param {object} graphData - Graph data
  * @param {Line} control - Line instance
  */
-const addShapesDuringFlow = (graph, graphData, control) => {
-  /* If data belongs to yAxis and shape associated with data id in yAxis is empty then prepareLabelShapeItem method gets executed to add shape in yAxis
-   else if data belongs to y2Axis and shape associated with data id in y2Axis is empty then prepareLabelShapeItem method gets executed to add shapes in y2Axes. */
-  if (control.config.yAxis === 'y' && (graph.svg.select(`.${styles.axisLabelYShapeContainer} svg[aria-describedby="${graphData.key}"]`).empty())) {
-    prepareLabelShapeItem(
-      graph.config,
-      control.dataTarget,
-      graph.axesLabelShapeGroup[control.config.yAxis],
-    );
-  } else if (control.config.yAxis === 'y2' && (graph.svg.select(`.${styles.axisLabelY2ShapeContainer} svg[aria-describedby="${graphData.key}"]`).empty())) {
+const updateShapesDuringReflow = (graph, graphData, control) => {
+  removeLabelShapeItem(
+    graph.axesLabelShapeGroup[control.config.yAxis],
+    control.dataTarget,
+    graph.config,
+  );
+  if (!utils.isEmpty(graphData.values)) {
     prepareLabelShapeItem(
       graph.config,
       control.dataTarget,
@@ -375,5 +372,5 @@ export {
   truncateLabel,
   createTooltipDiv,
   destroyTooltipDiv,
-  addShapesDuringFlow,
+  updateShapesDuringReflow,
 };

--- a/packages/carbon-graphs/src/js/helpers/label.js
+++ b/packages/carbon-graphs/src/js/helpers/label.js
@@ -337,6 +337,32 @@ const destroyTooltipDiv = () => {
 };
 
 /**
+ * Add shapes to y and y2 axes during reflow.
+ *
+ * @private
+ * @param {object} graph - Graph instance
+ * @param {object} graphData - Graph data
+ * @param {Line} control - Line instance
+ */
+const addShapesDuringFlow = (graph, graphData, control) => {
+  /* If data belongs to yAxis and shape associated with data id in yAxis is empty then prepareLabelShapeItem method gets executed to add shape in yAxis
+   else if data belongs to y2Axis and shape associated with data id in y2Axis is empty then prepareLabelShapeItem method gets executed to add shapes in y2Axes. */
+  if (control.config.yAxis === 'y' && (graph.svg.select(`.${styles.axisLabelYShapeContainer} svg[aria-describedby="${graphData.key}"]`).empty())) {
+    prepareLabelShapeItem(
+      graph.config,
+      control.dataTarget,
+      graph.axesLabelShapeGroup[control.config.yAxis],
+    );
+  } else if (control.config.yAxis === 'y2' && (graph.svg.select(`.${styles.axisLabelY2ShapeContainer} svg[aria-describedby="${graphData.key}"]`).empty())) {
+    prepareLabelShapeItem(
+      graph.config,
+      control.dataTarget,
+      graph.axesLabelShapeGroup[control.config.yAxis],
+    );
+  }
+};
+
+/**
  * @enum {Function}
  */
 export {
@@ -349,4 +375,5 @@ export {
   truncateLabel,
   createTooltipDiv,
   destroyTooltipDiv,
+  addShapesDuringFlow,
 };

--- a/packages/carbon-graphs/src/js/helpers/label.js
+++ b/packages/carbon-graphs/src/js/helpers/label.js
@@ -342,7 +342,7 @@ const destroyTooltipDiv = () => {
  * @private
  * @param {object} graph - Graph instance
  * @param {object} graphData - Graph data
- * @param {Line} control - Line instance
+ * @param {object} control - data instance
  */
 const updateShapesDuringReflow = (graph, graphData, control) => {
   removeLabelShapeItem(

--- a/packages/carbon-graphs/tests/unit/controls/Bar/BarPanningMultipleDatasets-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Bar/BarPanningMultipleDatasets-spec.js
@@ -319,6 +319,120 @@ describe('Bar - Panning', () => {
         expect(barContent[0].querySelectorAll('svg').length).toBe(0);
       });
     });
+    describe('when data values updates during reflow', () => {
+      const graphData = {
+        panData: [
+          {
+            key: 'uid_1',
+            values: [],
+          },
+          {
+            key: 'uid_2',
+            values: [],
+          },
+
+        ],
+      };
+      const graphData1 = {
+        panData: [
+          {
+            key: 'uid_1',
+            values: [
+              {
+                x: '2016-03-03T12:00:00Z',
+                y: 2,
+              },
+              {
+                x: '2016-04-03T12:00:00Z',
+                y: 20,
+              },
+            ],
+          },
+          {
+            key: 'uid_2',
+            values: [
+              {
+                x: '2016-03-03T12:00:00Z',
+                y: 2,
+              },
+              {
+                x: '2016-04-03T12:00:00Z',
+                y: 20,
+              },
+            ],
+          },
+        ],
+      };
+      beforeEach(() => {
+        graphDefault.destroy();
+        const axisData = utils.deepClone(getAxes(axisTimeSeries));
+
+        axisData.pan = { enabled: true };
+        axisData.showLabel = true;
+        const input = getInput(valuesTimeSeries, false, false);
+        const input1 = getInput(valuesTimeSeries, false, true, true);
+        input1.key = 'uid_2';
+        graphDefault = new Graph(axisData);
+        graphDefault.loadContent(new Bar(input));
+        graphDefault.loadContent(new Bar(input1));
+      });
+      it('should add shapes in both y and y2 axis when there is noData in previous state', () => {
+        const barShapeContentY = fetchAllElementsByClass(
+          barGraphContainer,
+          styles.axisLabelYShapeContainer,
+        );
+        const barShapeContentY2 = fetchAllElementsByClass(
+          barGraphContainer,
+          styles.axisLabelYShapeContainer,
+        );
+        expect(
+          barShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+        expect(
+          barShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+
+        graphDefault.reflowMultipleDatasets(graphData);
+        expect(
+          barShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(0);
+        expect(
+          barShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(0);
+
+        graphDefault.reflowMultipleDatasets(graphData1);
+        expect(
+          barShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+        expect(
+          barShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+      });
+      it('should keep shapes as is in both y and y2 axis when there is no noData in previous state', () => {
+        const barShapeContentY = fetchAllElementsByClass(
+          barGraphContainer,
+          styles.axisLabelYShapeContainer,
+        );
+        const barShapeContentY2 = fetchAllElementsByClass(
+          barGraphContainer,
+          styles.axisLabelYShapeContainer,
+        );
+        expect(
+          barShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+        expect(
+          barShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+
+        graphDefault.reflowMultipleDatasets(graphData1);
+        expect(
+          barShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+        expect(
+          barShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+      });
+    });
   });
   describe('When disabled', () => {
     beforeEach(() => {

--- a/packages/carbon-graphs/tests/unit/controls/Bar/BarPanningMultipleDatasets-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Bar/BarPanningMultipleDatasets-spec.js
@@ -21,6 +21,7 @@ import {
 import { getSVGAnimatedTransformList } from '../../../../src/js/helpers/transformUtils';
 import { COLORS, SHAPES } from '../../../../src/js/helpers/constants';
 import errors from '../../../../src/js/helpers/errors';
+import Scatter from '../../../../src/js/controls/Scatter';
 
 describe('Bar - Panning', () => {
   let graphDefault = null;
@@ -383,7 +384,7 @@ describe('Bar - Panning', () => {
         );
         const barShapeContentY2 = fetchAllElementsByClass(
           barGraphContainer,
-          styles.axisLabelYShapeContainer,
+          styles.axisLabelY2ShapeContainer,
         );
         expect(
           barShapeContentY[0].querySelectorAll('svg').length,
@@ -415,7 +416,7 @@ describe('Bar - Panning', () => {
         );
         const barShapeContentY2 = fetchAllElementsByClass(
           barGraphContainer,
-          styles.axisLabelYShapeContainer,
+          styles.axisLabelY2ShapeContainer,
         );
         expect(
           barShapeContentY[0].querySelectorAll('svg').length,
@@ -431,6 +432,123 @@ describe('Bar - Panning', () => {
         expect(
           barShapeContentY2[0].querySelectorAll('svg').length,
         ).toEqual(1);
+      });
+    });
+    describe('when there is more than one data set in single axis', () => {
+      const graphData = {
+        panData: [
+          {
+            x: '2016-03-03T12:00:00Z',
+            y: 2,
+          },
+          {
+            key: 'uid_2',
+            values: [],
+          },
+
+        ],
+      };
+      const graphData1 = {
+        panData: [
+          {
+            key: 'uid_1',
+            values: [
+              {
+                x: '2016-03-03T12:00:00Z',
+                y: 2,
+              },
+              {
+                x: '2016-04-03T12:00:00Z',
+                y: 20,
+              },
+            ],
+          },
+          {
+            key: 'uid_2',
+            values: [
+              {
+                x: '2016-03-03T12:00:00Z',
+                y: 2,
+              },
+              {
+                x: '2016-04-03T12:00:00Z',
+                y: 20,
+              },
+            ],
+          },
+        ],
+      };
+      it('should add and remove one shape in y-axis successfully during reflow', () => {
+        graphDefault.destroy();
+        const axisData = utils.deepClone(getAxes(axisTimeSeries));
+
+        axisData.pan = { enabled: true };
+        axisData.showLabel = true;
+        const input = getInput(valuesTimeSeries, false, false);
+        const input1 = getInput(valuesTimeSeries, false, true);
+        input1.key = 'uid_2';
+        graphDefault = new Graph(axisData);
+        graphDefault.loadContent(new Bar(input));
+        graphDefault.loadContent(new Bar(input1));
+        const barShapeContentY = fetchAllElementsByClass(
+          barGraphContainer,
+          styles.axisLabelYShapeContainer,
+        );
+        expect(
+          barShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(2);
+
+        graphDefault.reflowMultipleDatasets(graphData);
+        expect(
+          barShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+        expect(
+          barShapeContentY[0].querySelectorAll('svg[aria-describedby="uid_2"]')[0],
+        ).toEqual(undefined);
+
+        graphDefault.reflowMultipleDatasets(graphData1);
+        expect(
+          barShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(2);
+        expect(
+          barShapeContentY[0].querySelectorAll('svg[aria-describedby="uid_2"]')[0],
+        ).not.toBeNull();
+      });
+      it('should add and remove one shape in y2-axis successfully during reflow', () => {
+        graphDefault.destroy();
+        const axisData = utils.deepClone(getAxes(axisTimeSeries));
+
+        axisData.pan = { enabled: true };
+        axisData.showLabel = true;
+        const input = getInput(valuesTimeSeries, false, false, true);
+        const input1 = getInput(valuesTimeSeries, false, true, true);
+        input1.key = 'uid_2';
+        graphDefault = new Graph(axisData);
+        graphDefault.loadContent(new Bar(input));
+        graphDefault.loadContent(new Bar(input1));
+        const barShapeContentY2 = fetchAllElementsByClass(
+          barGraphContainer,
+          styles.axisLabelY2ShapeContainer,
+        );
+        expect(
+          barShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(2);
+
+        graphDefault.reflowMultipleDatasets(graphData);
+        expect(
+          barShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+        expect(
+          barShapeContentY2[0].querySelectorAll('svg[aria-describedby="uid_2"]')[0],
+        ).toEqual(undefined);
+
+        graphDefault.reflowMultipleDatasets(graphData1);
+        expect(
+          barShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(2);
+        expect(
+          barShapeContentY2[0].querySelectorAll('svg[aria-describedby="uid_2"]')[0],
+        ).not.toBeNull();
       });
     });
   });

--- a/packages/carbon-graphs/tests/unit/controls/Bar/BarPanningMultipleDatasets-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Bar/BarPanningMultipleDatasets-spec.js
@@ -21,7 +21,6 @@ import {
 import { getSVGAnimatedTransformList } from '../../../../src/js/helpers/transformUtils';
 import { COLORS, SHAPES } from '../../../../src/js/helpers/constants';
 import errors from '../../../../src/js/helpers/errors';
-import Scatter from '../../../../src/js/controls/Scatter';
 
 describe('Bar - Panning', () => {
   let graphDefault = null;

--- a/packages/carbon-graphs/tests/unit/controls/Line/LinePanningMultipleDatasets-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Line/LinePanningMultipleDatasets-spec.js
@@ -314,6 +314,120 @@ describe('Line - Panning', () => {
         ).toEqual(0);
       });
     });
+    describe('when data values updates during reflow', () => {
+      const graphData = {
+        panData: [
+          {
+            key: 'uid_1',
+            values: [],
+          },
+          {
+            key: 'uid_2',
+            values: [],
+          },
+
+        ],
+      };
+      const graphData1 = {
+        panData: [
+          {
+            key: 'uid_1',
+            values: [
+              {
+                x: '2016-03-03T12:00:00Z',
+                y: 2,
+              },
+              {
+                x: '2016-04-03T12:00:00Z',
+                y: 20,
+              },
+            ],
+          },
+          {
+            key: 'uid_2',
+            values: [
+              {
+                x: '2016-03-03T12:00:00Z',
+                y: 2,
+              },
+              {
+                x: '2016-04-03T12:00:00Z',
+                y: 20,
+              },
+            ],
+          },
+        ],
+      };
+      beforeEach(() => {
+        graphDefault.destroy();
+        const axisData = utils.deepClone(getAxes(axisTimeSeries));
+
+        axisData.pan = { enabled: true };
+        axisData.showLabel = true;
+        const input = getInput(valuesTimeSeries, false, false);
+        const input1 = getInput(valuesTimeSeries, false, true, true);
+        input1.key = 'uid_2';
+        graphDefault = new Graph(axisData);
+        graphDefault.loadContent(new Line(input));
+        graphDefault.loadContent(new Line(input1));
+      });
+      it('should add shapes in both y and y2 axis when there is noData in previous state', () => {
+        const lineShapeContentY = fetchAllElementsByClass(
+          lineGraphContainer,
+          styles.axisLabelYShapeContainer,
+        );
+        const lineShapeContentY2 = fetchAllElementsByClass(
+          lineGraphContainer,
+          styles.axisLabelYShapeContainer,
+        );
+        expect(
+          lineShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+        expect(
+          lineShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+
+        graphDefault.reflowMultipleDatasets(graphData);
+        expect(
+          lineShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(0);
+        expect(
+          lineShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(0);
+
+        graphDefault.reflowMultipleDatasets(graphData1);
+        expect(
+          lineShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+        expect(
+          lineShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+      });
+      it('should keep shapes as is in both y and y2 axis when there is no noData in previous state', () => {
+        const lineShapeContentY = fetchAllElementsByClass(
+          lineGraphContainer,
+          styles.axisLabelYShapeContainer,
+        );
+        const lineShapeContentY2 = fetchAllElementsByClass(
+          lineGraphContainer,
+          styles.axisLabelYShapeContainer,
+        );
+        expect(
+          lineShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+        expect(
+          lineShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+
+        graphDefault.reflowMultipleDatasets(graphData1);
+        expect(
+          lineShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+        expect(
+          lineShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+      });
+    });
   });
   describe('When values are non-contiguous', () => {
     beforeEach(() => {

--- a/packages/carbon-graphs/tests/unit/controls/Line/LinePanningMultipleDatasets-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Line/LinePanningMultipleDatasets-spec.js
@@ -378,7 +378,7 @@ describe('Line - Panning', () => {
         );
         const lineShapeContentY2 = fetchAllElementsByClass(
           lineGraphContainer,
-          styles.axisLabelYShapeContainer,
+          styles.axisLabelY2ShapeContainer,
         );
         expect(
           lineShapeContentY[0].querySelectorAll('svg').length,
@@ -410,7 +410,7 @@ describe('Line - Panning', () => {
         );
         const lineShapeContentY2 = fetchAllElementsByClass(
           lineGraphContainer,
-          styles.axisLabelYShapeContainer,
+          styles.axisLabelY2ShapeContainer,
         );
         expect(
           lineShapeContentY[0].querySelectorAll('svg').length,
@@ -426,6 +426,123 @@ describe('Line - Panning', () => {
         expect(
           lineShapeContentY2[0].querySelectorAll('svg').length,
         ).toEqual(1);
+      });
+    });
+    describe('when there is more than one data set in single axis', () => {
+      const graphData = {
+        panData: [
+          {
+            x: '2016-03-03T12:00:00Z',
+            y: 2,
+          },
+          {
+            key: 'uid_2',
+            values: [],
+          },
+
+        ],
+      };
+      const graphData1 = {
+        panData: [
+          {
+            key: 'uid_1',
+            values: [
+              {
+                x: '2016-03-03T12:00:00Z',
+                y: 2,
+              },
+              {
+                x: '2016-04-03T12:00:00Z',
+                y: 20,
+              },
+            ],
+          },
+          {
+            key: 'uid_2',
+            values: [
+              {
+                x: '2016-03-03T12:00:00Z',
+                y: 2,
+              },
+              {
+                x: '2016-04-03T12:00:00Z',
+                y: 20,
+              },
+            ],
+          },
+        ],
+      };
+      it('should add and remove one shape in y-axis successfully during reflow', () => {
+        graphDefault.destroy();
+        const axisData = utils.deepClone(getAxes(axisTimeSeries));
+
+        axisData.pan = { enabled: true };
+        axisData.showLabel = true;
+        const input = getInput(valuesTimeSeries, false, false);
+        const input1 = getInput(valuesTimeSeries, false, true);
+        input1.key = 'uid_2';
+        graphDefault = new Graph(axisData);
+        graphDefault.loadContent(new Line(input));
+        graphDefault.loadContent(new Line(input1));
+        const lineShapeContentY = fetchAllElementsByClass(
+          lineGraphContainer,
+          styles.axisLabelYShapeContainer,
+        );
+        expect(
+          lineShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(2);
+
+        graphDefault.reflowMultipleDatasets(graphData);
+        expect(
+          lineShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+        expect(
+          lineShapeContentY[0].querySelectorAll('svg[aria-describedby="uid_2"]')[0],
+        ).toEqual(undefined);
+
+        graphDefault.reflowMultipleDatasets(graphData1);
+        expect(
+          lineShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(2);
+        expect(
+          lineShapeContentY[0].querySelectorAll('svg[aria-describedby="uid_2"]')[0],
+        ).not.toBeNull();
+      });
+      it('should add and remove one shape in y2-axis successfully during reflow', () => {
+        graphDefault.destroy();
+        const axisData = utils.deepClone(getAxes(axisTimeSeries));
+
+        axisData.pan = { enabled: true };
+        axisData.showLabel = true;
+        const input = getInput(valuesTimeSeries, false, false, true);
+        const input1 = getInput(valuesTimeSeries, false, true, true);
+        input1.key = 'uid_2';
+        graphDefault = new Graph(axisData);
+        graphDefault.loadContent(new Line(input));
+        graphDefault.loadContent(new Line(input1));
+        const lineShapeContentY2 = fetchAllElementsByClass(
+          lineGraphContainer,
+          styles.axisLabelY2ShapeContainer,
+        );
+        expect(
+          lineShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(2);
+
+        graphDefault.reflowMultipleDatasets(graphData);
+        expect(
+          lineShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+        expect(
+          lineShapeContentY2[0].querySelectorAll('svg[aria-describedby="uid_2"]')[0],
+        ).toEqual(undefined);
+
+        graphDefault.reflowMultipleDatasets(graphData1);
+        expect(
+          lineShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(2);
+        expect(
+          lineShapeContentY2[0].querySelectorAll('svg[aria-describedby="uid_2"]')[0],
+        ).not.toBeNull();
       });
     });
   });

--- a/packages/carbon-graphs/tests/unit/controls/PairedResult/PairedResultPanningMultipleDatasets-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/PairedResult/PairedResultPanningMultipleDatasets-spec.js
@@ -733,6 +733,132 @@ describe('PairedResult', () => {
         ).toEqual(0);
       });
     });
+    describe('when data values updates during reflow', () => {
+      const graphData = {
+        panData: [
+          {
+            key: 'uid_1',
+            values: [],
+          },
+          {
+            key: 'uid_2',
+            values: [],
+          },
+
+        ],
+      };
+      const graphData1 = {
+        panData: [
+          {
+            key: 'uid_1',
+            values: [
+              {
+                high: {
+                  x: '2016-09-18T12:00:00Z',
+                  y: 70,
+                },
+                mid: {
+                  x: '2016-09-19T02:00:00Z',
+                  y: 30,
+                },
+                low: {
+                  x: '2016-09-19T02:00:00Z',
+                  y: 10,
+                },
+              },
+            ],
+          },
+          {
+            key: 'uid_2',
+            values: [
+              {
+                high: {
+                  x: '2016-09-18T12:00:00Z',
+                  y: 70,
+                },
+                mid: {
+                  x: '2016-09-19T02:00:00Z',
+                  y: 30,
+                },
+                low: {
+                  x: '2016-09-19T02:00:00Z',
+                  y: 10,
+                },
+              },
+            ],
+          },
+        ],
+      };
+      beforeEach(() => {
+        graphDefault.destroy();
+        const axisData = utils.deepClone(getAxes(axisTimeSeries));
+
+        axisData.pan = { enabled: true };
+        axisData.showLabel = true;
+        const input = getInput(valuesTimeSeries, false, false);
+        const input1 = getInput(valuesTimeSeries, false, true, true);
+        input1.key = 'uid_2';
+        graphDefault = new Graph(axisData);
+        graphDefault.loadContent(new PairedResult(input));
+        graphDefault.loadContent(new PairedResult(input1));
+      });
+      it('should add shapes in both y and y2 axis when there is noData in previous state', () => {
+        const pairedResultShapeContentY = fetchAllElementsByClass(
+          pairedResultGraphContainer,
+          styles.axisLabelYShapeContainer,
+        );
+        const pairedResultShapeContentY2 = fetchAllElementsByClass(
+          pairedResultGraphContainer,
+          styles.axisLabelYShapeContainer,
+        );
+        expect(
+          pairedResultShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(3);
+        expect(
+          pairedResultShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(3);
+
+        graphDefault.reflowMultipleDatasets(graphData);
+        expect(
+          pairedResultShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(0);
+        expect(
+          pairedResultShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(0);
+
+        graphDefault.reflowMultipleDatasets(graphData1);
+        expect(
+          pairedResultShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(3);
+        expect(
+          pairedResultShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(3);
+      });
+      it('should keep shapes as is in both y and y2 axis when there is no noData in previous state', () => {
+        const pairedResultShapeContentY = fetchAllElementsByClass(
+          pairedResultGraphContainer,
+          styles.axisLabelYShapeContainer,
+        );
+        const pairedResultShapeContentY2 = fetchAllElementsByClass(
+          pairedResultGraphContainer,
+          styles.axisLabelYShapeContainer,
+        );
+        expect(
+          pairedResultShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(3);
+        expect(
+          pairedResultShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(3);
+
+        graphDefault.reflowMultipleDatasets(graphData1);
+        expect(
+          pairedResultShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(3);
+        expect(
+          pairedResultShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(3);
+      });
+    });
   });
   describe('When pan is disabled', () => {
     beforeEach(() => {

--- a/packages/carbon-graphs/tests/unit/controls/PairedResult/PairedResultPanningMultipleDatasets-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/PairedResult/PairedResultPanningMultipleDatasets-spec.js
@@ -809,7 +809,7 @@ describe('PairedResult', () => {
         );
         const pairedResultShapeContentY2 = fetchAllElementsByClass(
           pairedResultGraphContainer,
-          styles.axisLabelYShapeContainer,
+          styles.axisLabelY2ShapeContainer,
         );
         expect(
           pairedResultShapeContentY[0].querySelectorAll('svg').length,
@@ -841,7 +841,7 @@ describe('PairedResult', () => {
         );
         const pairedResultShapeContentY2 = fetchAllElementsByClass(
           pairedResultGraphContainer,
-          styles.axisLabelYShapeContainer,
+          styles.axisLabelY2ShapeContainer,
         );
         expect(
           pairedResultShapeContentY[0].querySelectorAll('svg').length,
@@ -857,6 +857,174 @@ describe('PairedResult', () => {
         expect(
           pairedResultShapeContentY2[0].querySelectorAll('svg').length,
         ).toEqual(3);
+      });
+    });
+    describe('when there is more than one data set in single axis', () => {
+      const graphData = {
+        panData: [
+          {
+            key: 'uid_1',
+            values: [
+              {
+                high: {
+                  x: '2016-09-18T12:00:00Z',
+                  y: 70,
+                },
+                mid: {
+                  x: '2016-09-19T02:00:00Z',
+                  y: 30,
+                },
+                low: {
+                  x: '2016-09-19T02:00:00Z',
+                  y: 10,
+                },
+              },
+            ],
+          },
+          {
+            key: 'uid_2',
+            values: [],
+          },
+
+        ],
+      };
+      const graphData1 = {
+        panData: [
+          {
+            key: 'uid_1',
+            values: [
+              {
+                high: {
+                  x: '2016-09-18T12:00:00Z',
+                  y: 70,
+                },
+                mid: {
+                  x: '2016-09-19T02:00:00Z',
+                  y: 30,
+                },
+                low: {
+                  x: '2016-09-19T02:00:00Z',
+                  y: 10,
+                },
+              },
+            ],
+          },
+          {
+            key: 'uid_2',
+            values: [
+              {
+                high: {
+                  x: '2016-09-18T12:00:00Z',
+                  y: 70,
+                },
+                mid: {
+                  x: '2016-09-19T02:00:00Z',
+                  y: 30,
+                },
+                low: {
+                  x: '2016-09-19T02:00:00Z',
+                  y: 10,
+                },
+              },
+            ],
+          },
+        ],
+      };
+      it('should add and remove one shape in y-axis successfully during reflow', () => {
+        graphDefault.destroy();
+        const axisData = utils.deepClone(getAxes(axisTimeSeries));
+
+        axisData.pan = { enabled: true };
+        axisData.showLabel = true;
+        const input = getInput(valuesTimeSeries, false, false);
+        const input1 = getInput(valuesTimeSeries, false, true);
+        input1.key = 'uid_2';
+        graphDefault = new Graph(axisData);
+        graphDefault.loadContent(new PairedResult(input));
+        graphDefault.loadContent(new PairedResult(input1));
+        const pairedResultShapeContentY = fetchAllElementsByClass(
+          pairedResultGraphContainer,
+          styles.axisLabelYShapeContainer,
+        );
+        expect(
+          pairedResultShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(6);
+
+        graphDefault.reflowMultipleDatasets(graphData);
+        expect(
+          pairedResultShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(3);
+        expect(
+          pairedResultShapeContentY[0].querySelectorAll('svg[aria-describedby="uid_2_high"]')[0],
+        ).toEqual(undefined);
+        expect(
+          pairedResultShapeContentY[0].querySelectorAll('svg[aria-describedby="uid_2_mid"]')[0],
+        ).toEqual(undefined);
+        expect(
+          pairedResultShapeContentY[0].querySelectorAll('svg[aria-describedby="uid_2_low"]')[0],
+        ).toEqual(undefined);
+
+        graphDefault.reflowMultipleDatasets(graphData1);
+        expect(
+          pairedResultShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(6);
+        expect(
+          pairedResultShapeContentY[0].querySelectorAll('svg[aria-describedby="uid_2_high"]')[0],
+        ).not.toBeNull();
+        expect(
+          pairedResultShapeContentY[0].querySelectorAll('svg[aria-describedby="uid_2_mid"]')[0],
+        ).not.toBeNull();
+        expect(
+          pairedResultShapeContentY[0].querySelectorAll('svg[aria-describedby="uid_2_low"]')[0],
+        ).not.toBeNull();
+      });
+      it('should add and remove one shape in y2-axis successfully during reflow', () => {
+        graphDefault.destroy();
+        const axisData = utils.deepClone(getAxes(axisTimeSeries));
+
+        axisData.pan = { enabled: true };
+        axisData.showLabel = true;
+        const input = getInput(valuesTimeSeries, false, false, true);
+        const input1 = getInput(valuesTimeSeries, false, true, true);
+        input1.key = 'uid_2';
+        graphDefault = new Graph(axisData);
+        graphDefault.loadContent(new PairedResult(input));
+        graphDefault.loadContent(new PairedResult(input1));
+        const pairedResultShapeContentY2 = fetchAllElementsByClass(
+          pairedResultGraphContainer,
+          styles.axisLabelY2ShapeContainer,
+        );
+        expect(
+          pairedResultShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(6);
+
+        graphDefault.reflowMultipleDatasets(graphData);
+        expect(
+          pairedResultShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(3);
+        expect(
+          pairedResultShapeContentY2[0].querySelectorAll('svg[aria-describedby="uid_2_high"]')[0],
+        ).toEqual(undefined);
+        expect(
+          pairedResultShapeContentY2[0].querySelectorAll('svg[aria-describedby="uid_2_mid"]')[0],
+        ).toEqual(undefined);
+        expect(
+          pairedResultShapeContentY2[0].querySelectorAll('svg[aria-describedby="uid_2_low"]')[0],
+        ).toEqual(undefined);
+
+        graphDefault.reflowMultipleDatasets(graphData1);
+        expect(
+          pairedResultShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(6);
+        expect(
+          pairedResultShapeContentY2[0].querySelectorAll('svg[aria-describedby="uid_2_high"]')[0],
+        ).not.toBeNull();
+        expect(
+          pairedResultShapeContentY2[0].querySelectorAll('svg[aria-describedby="uid_2_mid"]')[0],
+        ).not.toBeNull();
+        expect(
+          pairedResultShapeContentY2[0].querySelectorAll('svg[aria-describedby="uid_2_low"]')[0],
+        ).not.toBeNull();
       });
     });
   });

--- a/packages/carbon-graphs/tests/unit/controls/Scatter/ScatterPanningMultipleDatasets-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Scatter/ScatterPanningMultipleDatasets-spec.js
@@ -344,6 +344,120 @@ describe('Scatter - Panning', () => {
         ).toEqual(0);
       });
     });
+    describe('when data values updates during reflow', () => {
+      const graphData = {
+        panData: [
+          {
+            key: 'uid_1',
+            values: [],
+          },
+          {
+            key: 'uid_2',
+            values: [],
+          },
+
+        ],
+      };
+      const graphData1 = {
+        panData: [
+          {
+            key: 'uid_1',
+            values: [
+              {
+                x: '2016-03-03T12:00:00Z',
+                y: 2,
+              },
+              {
+                x: '2016-04-03T12:00:00Z',
+                y: 20,
+              },
+            ],
+          },
+          {
+            key: 'uid_2',
+            values: [
+              {
+                x: '2016-03-03T12:00:00Z',
+                y: 2,
+              },
+              {
+                x: '2016-04-03T12:00:00Z',
+                y: 20,
+              },
+            ],
+          },
+        ],
+      };
+      beforeEach(() => {
+        graphDefault.destroy();
+        const axisData = utils.deepClone(getAxes(axisTimeSeries));
+
+        axisData.pan = { enabled: true };
+        axisData.showLabel = true;
+        const input = getInput(valuesTimeSeries, false, false);
+        const input1 = getInput(valuesTimeSeries, false, true, true);
+        input1.key = 'uid_2';
+        graphDefault = new Graph(axisData);
+        graphDefault.loadContent(new Scatter(input));
+        graphDefault.loadContent(new Scatter(input1));
+      });
+      it('should add shapes in both y and y2 axis when there is noData in previous state', () => {
+        const scatterShapeContentY = fetchAllElementsByClass(
+          scatterGraphContainer,
+          styles.axisLabelYShapeContainer,
+        );
+        const scatterShapeContentY2 = fetchAllElementsByClass(
+          scatterGraphContainer,
+          styles.axisLabelYShapeContainer,
+        );
+        expect(
+          scatterShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+        expect(
+          scatterShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+
+        graphDefault.reflowMultipleDatasets(graphData);
+        expect(
+          scatterShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(0);
+        expect(
+          scatterShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(0);
+
+        graphDefault.reflowMultipleDatasets(graphData1);
+        expect(
+          scatterShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+        expect(
+          scatterShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+      });
+      it('should keep shapes as is in both y and y2 axis when there is no noData in previous state', () => {
+        const scatterShapeContentY = fetchAllElementsByClass(
+          scatterGraphContainer,
+          styles.axisLabelYShapeContainer,
+        );
+        const scatterShapeContentY2 = fetchAllElementsByClass(
+          scatterGraphContainer,
+          styles.axisLabelYShapeContainer,
+        );
+        expect(
+          scatterShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+        expect(
+          scatterShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+
+        graphDefault.reflowMultipleDatasets(graphData1);
+        expect(
+          scatterShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+        expect(
+          scatterShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+      });
+    });
   });
   describe('When pan is disabled', () => {
     beforeEach(() => {

--- a/packages/carbon-graphs/tests/unit/controls/Scatter/ScatterPanningMultipleDatasets-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Scatter/ScatterPanningMultipleDatasets-spec.js
@@ -408,7 +408,7 @@ describe('Scatter - Panning', () => {
         );
         const scatterShapeContentY2 = fetchAllElementsByClass(
           scatterGraphContainer,
-          styles.axisLabelYShapeContainer,
+          styles.axisLabelY2ShapeContainer,
         );
         expect(
           scatterShapeContentY[0].querySelectorAll('svg').length,
@@ -440,7 +440,7 @@ describe('Scatter - Panning', () => {
         );
         const scatterShapeContentY2 = fetchAllElementsByClass(
           scatterGraphContainer,
-          styles.axisLabelYShapeContainer,
+          styles.axisLabelY2ShapeContainer,
         );
         expect(
           scatterShapeContentY[0].querySelectorAll('svg').length,
@@ -456,6 +456,123 @@ describe('Scatter - Panning', () => {
         expect(
           scatterShapeContentY2[0].querySelectorAll('svg').length,
         ).toEqual(1);
+      });
+    });
+    describe('when there is more than one data set in single axis', () => {
+      const graphData = {
+        panData: [
+          {
+            x: '2016-03-03T12:00:00Z',
+            y: 2,
+          },
+          {
+            key: 'uid_2',
+            values: [],
+          },
+
+        ],
+      };
+      const graphData1 = {
+        panData: [
+          {
+            key: 'uid_1',
+            values: [
+              {
+                x: '2016-03-03T12:00:00Z',
+                y: 2,
+              },
+              {
+                x: '2016-04-03T12:00:00Z',
+                y: 20,
+              },
+            ],
+          },
+          {
+            key: 'uid_2',
+            values: [
+              {
+                x: '2016-03-03T12:00:00Z',
+                y: 2,
+              },
+              {
+                x: '2016-04-03T12:00:00Z',
+                y: 20,
+              },
+            ],
+          },
+        ],
+      };
+      it('should add and remove one shape in y-axis successfully during reflow', () => {
+        graphDefault.destroy();
+        const axisData = utils.deepClone(getAxes(axisTimeSeries));
+
+        axisData.pan = { enabled: true };
+        axisData.showLabel = true;
+        const input = getInput(valuesTimeSeries, false, false);
+        const input1 = getInput(valuesTimeSeries, false, true);
+        input1.key = 'uid_2';
+        graphDefault = new Graph(axisData);
+        graphDefault.loadContent(new Scatter(input));
+        graphDefault.loadContent(new Scatter(input1));
+        const scatterShapeContentY = fetchAllElementsByClass(
+          scatterGraphContainer,
+          styles.axisLabelYShapeContainer,
+        );
+        expect(
+          scatterShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(2);
+
+        graphDefault.reflowMultipleDatasets(graphData);
+        expect(
+          scatterShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+        expect(
+          scatterShapeContentY[0].querySelectorAll('svg[aria-describedby="uid_2"]')[0],
+        ).toEqual(undefined);
+
+        graphDefault.reflowMultipleDatasets(graphData1);
+        expect(
+          scatterShapeContentY[0].querySelectorAll('svg').length,
+        ).toEqual(2);
+        expect(
+          scatterShapeContentY[0].querySelectorAll('svg[aria-describedby="uid_2"]')[0],
+        ).not.toBeNull();
+      });
+      it('should add and remove one shape in y2-axis successfully during reflow', () => {
+        graphDefault.destroy();
+        const axisData = utils.deepClone(getAxes(axisTimeSeries));
+
+        axisData.pan = { enabled: true };
+        axisData.showLabel = true;
+        const input = getInput(valuesTimeSeries, false, false, true);
+        const input1 = getInput(valuesTimeSeries, false, true, true);
+        input1.key = 'uid_2';
+        graphDefault = new Graph(axisData);
+        graphDefault.loadContent(new Scatter(input));
+        graphDefault.loadContent(new Scatter(input1));
+        const scatterShapeContentY2 = fetchAllElementsByClass(
+          scatterGraphContainer,
+          styles.axisLabelY2ShapeContainer,
+        );
+        expect(
+          scatterShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(2);
+
+        graphDefault.reflowMultipleDatasets(graphData);
+        expect(
+          scatterShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(1);
+        expect(
+          scatterShapeContentY2[0].querySelectorAll('svg[aria-describedby="uid_2"]')[0],
+        ).toEqual(undefined);
+
+        graphDefault.reflowMultipleDatasets(graphData1);
+        expect(
+          scatterShapeContentY2[0].querySelectorAll('svg').length,
+        ).toEqual(2);
+        expect(
+          scatterShapeContentY2[0].querySelectorAll('svg[aria-describedby="uid_2"]')[0],
+        ).not.toBeNull();
       });
     });
   });


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->

Y-axis icons and y2-axis icons not updating based on the values passed down to the reflow. If there is no data for a particular legend, the y-axis icon should hide and if there is data for a particular legend during panning, y-axis icons should display.

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #87 

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-graphs-deployed-pr-45.herokuapp.com/ -->
https://terra-graphs-deployed-pr-#.herokuapp.com/

### Screenshots

#### Before(during reflow)
![image](https://user-images.githubusercontent.com/63670637/114468397-05937a80-9bb1-11eb-81b2-d7d8c041898a.png)

#### After(during reflow)
![image](https://user-images.githubusercontent.com/63670637/114468442-1e9c2b80-9bb1-11eb-8b7e-e2caf5a50910.png)

<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
@cerner/carbon
