### PR TITLE
Fixed isolation of different graph instances in same page.

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "terra-enzyme-intl": "^3.0.0",
     "terra-toolkit": "^6.2.0",
     "url-loader": "^4.1.1",
+    "uuidv4": "^3.0.0",
     "webpack": "^4.30.0",
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "terra-enzyme-intl": "^3.0.0",
     "terra-toolkit": "^6.2.0",
     "url-loader": "^4.1.1",
-    "uuidv4": "^3.0.0",
+    "uuid": "^3.0.0",
     "webpack": "^4.30.0",
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.3.1",

--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed 
+  * Fixed different graphs isolation of different instances in same page.
+  
 ## 2.17.0 - (April 27, 2021)
 
 * Changed 

--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Changed 
-  * Fixed different graphs isolation of different instances in same page.
+  * Fixed isolation of different graph instances in same page.
   
 ## 2.17.0 - (April 27, 2021)
 

--- a/packages/carbon-graphs/src/js/core/BaseConfig/helper.js
+++ b/packages/carbon-graphs/src/js/core/BaseConfig/helper.js
@@ -7,11 +7,6 @@ import errors from '../../helpers/errors';
 import utils from '../../helpers/utils';
 
 /**
- * Creates random ID
- */
-const idRef = () => uuidv4();
-
-/**
  * Validates and verifies the input JSON object
  * Checks following properties:
  * Tests if Input is present
@@ -63,7 +58,7 @@ export const getType = (type) => getDefaultValue(type, AXIS_TYPE.DEFAULT);
  * @private
  * @returns {string} Clip path ID
  */
-export const generateClipPathId = () => `carbon-${idRef()}-clip`;
+export const generateClipPathId = () => `carbon-${uuidv4()}-clip`;
 
 /**
  * Generates a clip path ID for Dateline with uuidv4()
@@ -71,7 +66,7 @@ export const generateClipPathId = () => `carbon-${idRef()}-clip`;
  * @private
  * @returns {string} Clip path Dateline ID
  */
-export const generateDatelineClipPathId = () => `carbon-${idRef()}-dateline-clip`;
+export const generateDatelineClipPathId = () => `carbon-${uuidv4()}-dateline-clip`;
 /**
  * Interpolation type can be:
  * * Linear (default)

--- a/packages/carbon-graphs/src/js/core/BaseConfig/helper.js
+++ b/packages/carbon-graphs/src/js/core/BaseConfig/helper.js
@@ -1,9 +1,15 @@
 'use strict';
 
 import * as d3 from 'd3';
+import uuidv4 from 'uuid/v4';
 import { AXIS_TYPE, LINE_TYPE } from '../../helpers/constants';
 import errors from '../../helpers/errors';
 import utils from '../../helpers/utils';
+
+/**
+ * Creates random ID
+ */
+const idRef = () => uuidv4();
 
 /**
  * Validates and verifies the input JSON object
@@ -57,7 +63,7 @@ export const getType = (type) => getDefaultValue(type, AXIS_TYPE.DEFAULT);
  * @private
  * @returns {string} Clip path ID
  */
-export const generateClipPathId = () => `carbon-${+new Date()}-clip`;
+export const generateClipPathId = () => `carbon-${+new Date()}-${idRef()}-clip`;
 
 /**
  * Generates a clip path ID for Dateline based on current date
@@ -65,7 +71,7 @@ export const generateClipPathId = () => `carbon-${+new Date()}-clip`;
  * @private
  * @returns {string} Clip path Dateline ID
  */
-export const generateDatelineClipPathId = () => `carbon-${+new Date()}-dateline-clip`;
+export const generateDatelineClipPathId = () => `carbon-${+new Date()}-${idRef()}-dateline-clip`;
 /**
  * Interpolation type can be:
  * * Linear (default)

--- a/packages/carbon-graphs/src/js/core/BaseConfig/helper.js
+++ b/packages/carbon-graphs/src/js/core/BaseConfig/helper.js
@@ -58,20 +58,20 @@ export const getDefaultValue = (value, defaultVal) => (utils.isUndefined(value) 
  */
 export const getType = (type) => getDefaultValue(type, AXIS_TYPE.DEFAULT);
 /**
- * Generates a clip path ID based on current date
+ * Generates a unique clip path ID with uuidv4().
  *
  * @private
  * @returns {string} Clip path ID
  */
-export const generateClipPathId = () => `carbon-${+new Date()}-${idRef()}-clip`;
+export const generateClipPathId = () => `carbon-${idRef()}-clip`;
 
 /**
- * Generates a clip path ID for Dateline based on current date
+ * Generates a clip path ID for Dateline with uuidv4()
  *
  * @private
  * @returns {string} Clip path Dateline ID
  */
-export const generateDatelineClipPathId = () => `carbon-${+new Date()}-${idRef()}-dateline-clip`;
+export const generateDatelineClipPathId = () => `carbon-${idRef()}-dateline-clip`;
 /**
  * Interpolation type can be:
  * * Linear (default)

--- a/packages/carbon-graphs/tests/unit/controls/Graph/GraphDateline-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Graph/GraphDateline-spec.js
@@ -396,4 +396,20 @@ describe('Graph - Dateline', () => {
       });
     });
   });
+  describe('Generate different clip-path id', () => {
+    it('When two graph instances are created in same page', () => {
+      const input = utils.deepClone(getAxes(axisTimeSeries));
+      graph = new Graph(input);
+      graph.loadContent(new Line(getData(valuesTimeSeries)));
+      const input1 = utils.deepClone(getAxes(axisTimeSeries));
+      input1.key = 'uid_1';
+      graph = new Graph(input1);
+      graph.loadContent(new Line(getData(valuesTimeSeries)));
+
+      const clipPathID = document.querySelectorAll('clipPath');
+      expect(
+        clipPathID[0] === clipPathID[1],
+      ).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
- Two Gantt instances on the same page are not fully isolated as they should be. This leads to strange effects such as collapsing sections of the first Gantt causes data on the second Gantt to be removed. 
- Fixed this by adding unique id to clippath.
<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #98 

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-graphs-deployed-pr-45.herokuapp.com/ -->
https://terra-graphs-deployed-pr-#.herokuapp.com/

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
@cerner/carbon
