### PR TITLE
Fixed a bug causing the UI glitch while rendering graphs having y2 axis.

### DIFF
--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Fixed a bug causing the UI glitch while rendering graphs having Y2 axis.
+
 ## 2.17.2 - (June 15, 2021)
 
 * Changed

--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Changed
-  * Fixed a bug causing the UI glitch while rendering graphs having Y2 axis.
+  * Fixed a bug causing a UI glitch while rendering graphs having Y2 axis.
 
 ## 2.17.2 - (June 15, 2021)
 

--- a/packages/carbon-graphs/src/js/helpers/label.js
+++ b/packages/carbon-graphs/src/js/helpers/label.js
@@ -176,12 +176,12 @@ const translateYAxisLabelShapeContainer = (config, shapeContainerPath) => shapeC
   .call(constants.d3Transition(config.settingsDictionary.transition))
   .attr(
     'transform',
-    `translate(${getYAxisLabelShapeXPosition(
-      config,
-    )}, ${getYAxisLabelShapeYPosition(
-      config,
-      getShapeContainerSize(shapeContainerPath),
-    )}) rotate(${getRotationForAxis(constants.Y_AXIS)})`,
+      `translate(${getYAxisLabelShapeXPosition(
+        config,
+      )}, ${getYAxisLabelShapeYPosition(
+        config,
+        getShapeContainerSize(shapeContainerPath),
+      )}) rotate(${getRotationForAxis(constants.Y_AXIS)})`,
   );
 /**
  * Translates Y2 Axis label shape container to correct position. Typically this is
@@ -217,6 +217,15 @@ const buildYAxisLabelShapeContainer = (config, canvasPath) => {
   const path = canvasPath
     .append('g')
     .classed(styles.axisLabelYShapeContainer, true);
+  path.attr(
+    'transform',
+      `translate(${getYAxisLabelShapeXPosition(
+        config,
+      )}, ${getYAxisLabelShapeYPosition(
+        config,
+        getShapeContainerSize(path),
+      )})`,
+  );
   translateYAxisLabelShapeContainer(config, path);
   return path;
 };
@@ -232,6 +241,16 @@ const buildY2AxisLabelShapeContainer = (config, canvasPath) => {
   const path = canvasPath
     .append('g')
     .classed(styles.axisLabelY2ShapeContainer, true);
+  path.attr(
+    'transform',
+    `translate(${getY2AxisLabelShapeXPosition(
+      config,
+    )}, ${getY2AxisLabelShapeYPosition(
+      config,
+      getShapeContainerSize(path),
+    )})`,
+  );
+
   translateY2AxisLabelShapeContainer(config, path);
   return path;
 };

--- a/packages/carbon-graphs/tests/unit/controls/Graph/GraphAxes-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Graph/GraphAxes-spec.js
@@ -8,7 +8,7 @@ import constants, {
   AXES_ORIENTATION,
 } from '../../../../src/js/helpers/constants';
 import styles from '../../../../src/js/helpers/styles';
-import { getSVGAnimatedTransformList } from '../../../../src/js/helpers/transformUtils';
+import { getCurrentTransform, getSVGAnimatedTransformList } from '../../../../src/js/helpers/transformUtils';
 import utils from '../../../../src/js/helpers/utils';
 import LOCALE from '../../../../src/js/locale/index';
 import {
@@ -2017,6 +2017,43 @@ describe('Graph - Axes', () => {
       expect(
         fetchElementByClass(styles.labelPopupTooltip),
       ).not.toBeNull();
+    });
+    describe('when y2Axis is true', () => {
+      beforeEach(() => {
+        graph.destroy();
+        const axisObj = utils.deepClone(axisDefault);
+        axisObj.y2 = {
+          show: true,
+          label: 'y2 axis',
+          lowerLimit: 11,
+          upperLimit: 25,
+        };
+        graph = new Graph({ ...getAxes(axisObj) });
+      });
+      it('should add correct transform point to y-axis label shape container', () => {
+        expect(
+          getSVGAnimatedTransformList(
+            getCurrentTransform(fetchElementByClass(styles.axisLabelYShapeContainer)),
+          ).translate[0],
+        ).toBe(25.5);
+        expect(
+          getSVGAnimatedTransformList(
+            getCurrentTransform(fetchElementByClass(styles.axisLabelYShapeContainer)),
+          ).translate[1],
+        ).toBe(117.5);
+      });
+      it('should add correct transform point to y2-axis label shape container', () => {
+        expect(
+          getSVGAnimatedTransformList(
+            getCurrentTransform(fetchElementByClass(styles.axisLabelY2ShapeContainer)),
+          ).translate[0],
+        ).toBe(991.375);
+        expect(
+          getSVGAnimatedTransformList(
+            getCurrentTransform(fetchElementByClass(styles.axisLabelY2ShapeContainer)),
+          ).translate[1],
+        ).toBe(117.5);
+      });
     });
   });
   describe('when graph is destroyed', () => {

--- a/packages/carbon-graphs/tests/unit/controls/Graph/GraphAxes-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Graph/GraphAxes-spec.js
@@ -2030,7 +2030,7 @@ describe('Graph - Axes', () => {
         };
         graph = new Graph({ ...getAxes(axisObj) });
       });
-      it('should add correct transform point to y-axis label shape container', () => {
+      it('should add the correct transform point to y-axis label shape container', () => {
         expect(
           getSVGAnimatedTransformList(
             getCurrentTransform(fetchElementByClass(styles.axisLabelYShapeContainer)),
@@ -2042,7 +2042,7 @@ describe('Graph - Axes', () => {
           ).translate[1],
         ).toBe(117.5);
       });
-      it('should add correct transform point to y2-axis label shape container', () => {
+      it('should add the correct transform point to y2-axis label shape container', () => {
         expect(
           getSVGAnimatedTransformList(
             getCurrentTransform(fetchElementByClass(styles.axisLabelY2ShapeContainer)),


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
- Fixed a bug that is causing UI glitch while redering graph with y2 axis by adding transform points for label shape container at the first place.
<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #192  

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-graphs-deployed-pr-45.herokuapp.com/ -->
https://terra-graphs-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->
 - All tests are running successfully.
 - Added a test case to test transform points at the first place.

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
@cerner/carbon
