### PR TITLE
Adding x-axis calibration for a numerical x-axis

### DIFF
--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added
   * Added preliminary logic for new prop `config.axis.x.allowCalibration` to automatically update axis limits to allow padding.
+  * Finished implementation for `config.axis.x.allowCalibration` for a line graph with a numerical x-axis.
 
 ## 2.21.0 - (February 15, 2022)
 

--- a/packages/carbon-graphs/src/js/controls/Gantt/Gantt.js
+++ b/packages/carbon-graphs/src/js/controls/Gantt/Gantt.js
@@ -2,7 +2,7 @@
 
 import * as d3 from 'd3';
 import Construct from '../../core/Construct';
-import { getYAxisHeight, updateXAxisDomain } from '../../helpers/axis';
+import { getYAxisHeight, setXAxisDomain } from '../../helpers/axis';
 import constants from '../../helpers/constants';
 import { contentHandler } from '../../helpers/constructUtils';
 import { createDateline } from '../../helpers/dateline';
@@ -336,7 +336,7 @@ class Gantt extends Construct {
      */
   reflow(graphData) {
     console.warn('reflow is deprecated and will be removed a future major release. Please use reflowMultipleDatasets instead.');
-    updateXAxisDomain(this.config);
+    setXAxisDomain(this.config);
     scaleGraph(this.scale, this.config);
     const eventHandlers = prepareLegendEventHandlers(
       this,
@@ -375,7 +375,7 @@ class Gantt extends Construct {
      *  @returns {Gantt} - Gantt instance
      */
   reflowMultipleDatasets(graphData) {
-    updateXAxisDomain(this.config);
+    setXAxisDomain(this.config);
     scaleGraph(this.scale, this.config);
     const eventHandlers = prepareLegendEventHandlers(
       this,

--- a/packages/carbon-graphs/src/js/controls/Graph/Graph.js
+++ b/packages/carbon-graphs/src/js/controls/Graph/Graph.js
@@ -117,7 +117,7 @@ const beforeInit = (control) => {
   getAxesDataRange({}, '', control.config);
 
   if (utils.isDefined(control.config.axis.x.allowCalibration) && control.config.axis.x.allowCalibration) {
-    console.warn("allowCalibration for x-axis is a new feature that is currently a work in progress and may have stability issues. Use it at your own risk.")
+    console.warn('allowCalibration for x-axis is a new feature that is currently a work in progress and may have stability issues. Use it at your own risk.');
     getAxesDataRange({}, constants.X_AXIS, control.config);
   }
   updateAxesDomain(control.config);
@@ -361,9 +361,7 @@ class Graph extends Construct {
     setAxisPadding(this.config.axisPadding, content);
     getAxesDataRange(content, content.config.yAxis, this.config, this.content);
 
-
     if (utils.isDefined(this.config.axis.x.allowCalibration) && this.config.axis.x.allowCalibration) {
-      
       getAxesDataRange(content, constants.X_AXIS, this.config, this.content);
 
       if (isRangeModified(this.config, constants.X_AXIS)) {
@@ -546,7 +544,7 @@ class Graph extends Construct {
               this.config,
               this.content,
             );
-            
+
             if (
               this.config.allowCalibration
                   && isRangeModified(this.config, this.content[position].config.yAxis)

--- a/packages/carbon-graphs/src/js/controls/Graph/Graph.js
+++ b/packages/carbon-graphs/src/js/controls/Graph/Graph.js
@@ -11,7 +11,7 @@ import {
   createXAxisInfoRow,
   getAxesDataRange,
   getYAxisHeight,
-  updateXAxisDomain,
+  setXAxisDomain,
   translateAxes,
 } from '../../helpers/axis';
 import constants, { AXIS_TYPE, COLORS } from '../../helpers/constants';
@@ -44,6 +44,7 @@ import {
   translateGraph,
   translateContentContainer,
   updateAxesDomain,
+  updateXAxisDomain,
   handleLabelClickFunctionDuringReflow,
 } from './helpers/helpers';
 
@@ -114,7 +115,9 @@ const isRangeModified = (config, yAxis = constants.Y_AXIS) => config.axis[yAxis]
 const beforeInit = (control) => {
   control.graphContainer = d3.select(control.config.bindTo);
   getAxesDataRange({}, '', control.config);
+  getAxesDataRange({}, constants.X_AXIS, control.config);
   updateAxesDomain(control.config);
+  updateXAxisDomain(control.config);
   createTooltipDiv();
   return control;
 };
@@ -357,12 +360,25 @@ class Graph extends Construct {
       this.config,
       this.content,
     );
+    getAxesDataRange(
+      content,
+      constants.X_AXIS,
+      this.config,
+      this.content,
+    );
     if (
       this.config.allowCalibration
       && isRangeModified(this.config, content.config.yAxis)
     ) {
       updateAxesDomain(this.config, content);
     }
+
+    if (
+      this.config.axis.x.allowCalibration
+      && isRangeModified(this.config, constants.X_AXIS)
+    ) {
+      updateXAxisDomain(this.config, content);
+    }    
     content.load(this);
     if (
       utils.notEmpty(this.config.dateline)
@@ -485,7 +501,7 @@ class Graph extends Construct {
       redrawEventlineContent(this.scale, this.config, this.svg);
     }
 
-    updateXAxisDomain(this.config);
+    setXAxisDomain(this.config);
     scaleGraph(this.scale, this.config);
     translateAxes(this.axis, this.scale, this.config, this.svg);
     translateContentContainer(this.config, this.svg);
@@ -556,7 +572,7 @@ class Graph extends Construct {
       redrawEventlineContent(this.scale, this.config, this.svg);
     }
 
-    updateXAxisDomain(this.config);
+    setXAxisDomain(this.config);
     scaleGraph(this.scale, this.config);
     translateAxes(this.axis, this.scale, this.config, this.svg);
 

--- a/packages/carbon-graphs/src/js/controls/Graph/Graph.js
+++ b/packages/carbon-graphs/src/js/controls/Graph/Graph.js
@@ -546,6 +546,7 @@ class Graph extends Construct {
               this.config,
               this.content,
             );
+            
             if (
               this.config.allowCalibration
                   && isRangeModified(

--- a/packages/carbon-graphs/src/js/controls/Graph/Graph.js
+++ b/packages/carbon-graphs/src/js/controls/Graph/Graph.js
@@ -549,10 +549,7 @@ class Graph extends Construct {
             
             if (
               this.config.allowCalibration
-                  && isRangeModified(
-                    this.config,
-                    this.content[position].config.yAxis,
-                  )
+                  && isRangeModified(this.config, this.content[position].config.yAxis)
             ) {
               updateAxesDomain(this.config, this.content[position]);
             }

--- a/packages/carbon-graphs/src/js/controls/Graph/helpers/helpers.js
+++ b/packages/carbon-graphs/src/js/controls/Graph/helpers/helpers.js
@@ -444,7 +444,6 @@ const padDomain = (domain, isPaddingNeeded = true) => {
   const upperBound = domain.upperLimit;
   const domainRange = Math.abs(upperBound - lowerBound);
   const domainStretch = domainRange * (50 / 1000);
-  console.log('domainstretch: ', domainStretch);
   return {
     lowerLimit: lowerBound - (isPaddingNeeded ? domainStretch : 0),
     upperLimit: upperBound + (isPaddingNeeded ? domainStretch : 0),
@@ -469,7 +468,6 @@ const updateAxesDomain = (config, input = {}) => {
   }
 
   config.outlierStretchFactor = determineOutlierStretchFactor(config);
-  console.log(config.outlierStretchFactor);
 
   const yAxis = input.config.yAxis || constants.Y_AXIS;
 
@@ -503,11 +501,6 @@ const updateXAxisDomain = (config, input = {}) => {
   }
 
   config.axis.x.outlierStretchFactor = determineOutlierStretchFactorXAxis(config);
-  console.log(config.axis.x.outlierStretchFactor);
-
-  console.log('x-axis lowerLimit: ', config.axis.x.domain.lowerLimit);
-  console.log('x-axis upperLimit: ', config.axis.x.domain.upperLimit);
-
   config.axisPadding.x = false;
 
   const halfDomain = (config.axis.x.domain.upperLimit - config.axis.x.domain.lowerLimit) / 2;
@@ -518,9 +511,6 @@ const updateXAxisDomain = (config, input = {}) => {
   };
 
   config.axis.x.domain = padDomain(newDomain, config.axisPadding.x);
-
-  console.log('x-axis domain: ', config.axis.x.domain);
-  console.log(config.axisPadding);
 
   return config;
 };

--- a/packages/carbon-graphs/src/js/controls/Graph/helpers/helpers.js
+++ b/packages/carbon-graphs/src/js/controls/Graph/helpers/helpers.js
@@ -1,7 +1,9 @@
 'use strict';
 
 import * as d3 from 'd3';
-import { getScale } from '../../../core/BaseConfig/index';
+import { getScale, getDefaultValue } from '../../../core/BaseConfig/index';
+// import { getDefaultValue } from '../../core/BaseConfig';
+
 import {
   buildAxisLabel,
   calculateVerticalPadding,
@@ -501,7 +503,6 @@ const updateXAxisDomain = (config, input = {}) => {
   }
 
   config.axis.x.outlierStretchFactor = determineOutlierStretchFactorXAxis(config);
-  config.axisPadding.x = false;
 
   const halfDomain = (config.axis.x.domain.upperLimit - config.axis.x.domain.lowerLimit) / 2;
   const midPoint = (config.axis.x.domain.upperLimit + config.axis.x.domain.lowerLimit) / 2;
@@ -509,6 +510,15 @@ const updateXAxisDomain = (config, input = {}) => {
     lowerLimit: midPoint - halfDomain * config.axis.x.outlierStretchFactor.lowerLimit,
     upperLimit: midPoint + halfDomain * config.axis.x.outlierStretchFactor.upperLimit,
   };
+
+  if(newDomain.upperLimit == config.axis.x.dataRange.max
+     || newDomain.lowerLimit == config.axis.x.dataRange.min )
+  {
+    config.axisPadding.x = true;
+  } 
+  else {
+    config.axisPadding.x = getDefaultValue(config.axisPadding.x, false);
+  }
 
   config.axis.x.domain = padDomain(newDomain, config.axisPadding.x);
 

--- a/packages/carbon-graphs/src/js/controls/Graph/helpers/helpers.js
+++ b/packages/carbon-graphs/src/js/controls/Graph/helpers/helpers.js
@@ -510,12 +510,10 @@ const updateXAxisDomain = (config, input = {}) => {
     upperLimit: midPoint + halfDomain * config.axis.x.outlierStretchFactor.upperLimit,
   };
 
-  if(newDomain.upperLimit == config.axis.x.dataRange.max
-     || newDomain.lowerLimit == config.axis.x.dataRange.min )
-  {
+  if (newDomain.upperLimit === config.axis.x.dataRange.max
+     || newDomain.lowerLimit === config.axis.x.dataRange.min) {
     config.axisPadding.x = true;
-  } 
-  else {
+  } else {
     config.axisPadding.x = getDefaultValue(config.axisPadding.x, false);
   }
 

--- a/packages/carbon-graphs/src/js/controls/Graph/helpers/helpers.js
+++ b/packages/carbon-graphs/src/js/controls/Graph/helpers/helpers.js
@@ -444,7 +444,7 @@ const padDomain = (domain, isPaddingNeeded = true) => {
   const upperBound = domain.upperLimit;
   const domainRange = Math.abs(upperBound - lowerBound);
   const domainStretch = domainRange * (50 / 1000);
-  console.log("domainstretch: ", domainStretch);
+  console.log('domainstretch: ', domainStretch);
   return {
     lowerLimit: lowerBound - (isPaddingNeeded ? domainStretch : 0),
     upperLimit: upperBound + (isPaddingNeeded ? domainStretch : 0),
@@ -464,43 +464,28 @@ const padDomain = (domain, isPaddingNeeded = true) => {
  * @returns {object} config - config object derived from input JSON
  */
 const updateAxesDomain = (config, input = {}) => {
-
-  config.outlierStretchFactor = determineOutlierStretchFactor(config);
-  console.log(config.outlierStretchFactor);
-  // const setDomain = (outlierStretchFactor, lowerLimit, upperLimit, yAxis) => {
-  //   const halfDomain = (upperLimit - lowerLimit) / 2;
-  //   const midPoint = (upperLimit + lowerLimit) / 2;
-  //   return padDomain(
-  //     {
-  //       lowerLimit: midPoint - halfDomain * outlierStretchFactor.lowerLimit,
-  //       upperLimit: midPoint + halfDomain * outlierStretchFactor.upperLimit,
-  //     },
-  //     config.axisPadding[yAxis],
-  //   );
-  // };
-
-
-
-
   if (utils.isEmpty(input)) {
     return config;
   }
-  const yAxis = input.config.yAxis || constants.Y_AXIS;
 
+  config.outlierStretchFactor = determineOutlierStretchFactor(config);
+  console.log(config.outlierStretchFactor);
+
+  const yAxis = input.config.yAxis || constants.Y_AXIS;
 
   const halfDomain = (config.axis[yAxis].domain.upperLimit - config.axis[yAxis].domain.lowerLimit) / 2;
   const midPoint = (config.axis[yAxis].domain.upperLimit + config.axis[yAxis].domain.lowerLimit) / 2;
   const newDomain = {
-                      lowerLimit: midPoint - halfDomain * config.outlierStretchFactor.lowerLimit,
-                      upperLimit: midPoint + halfDomain * config.outlierStretchFactor.upperLimit,
-                    };
+    lowerLimit: midPoint - halfDomain * config.outlierStretchFactor.lowerLimit,
+    upperLimit: midPoint + halfDomain * config.outlierStretchFactor.upperLimit,
+  };
 
-  config.axis[yAxis].domain = padDomain( newDomain, config.axisPadding[yAxis]);
+  config.axis[yAxis].domain = padDomain(newDomain, config.axisPadding[yAxis]);
 
   return config;
 };
 /**
- * Determines the domain for x, y and y2 axes. For Y axis and Y2 axis,
+ * Determines the domain for the x axis.
  * the end points are calculated based on the ranges provided. This is done so that the axes are
  * padded on both ends properly.
  * For X Axis no such processing is provided. This decision was made due to the resize happening
@@ -512,35 +497,29 @@ const updateAxesDomain = (config, input = {}) => {
  * @param {object} [input] - array of target objects
  * @returns {object} config - config object derived from input JSON
  */
- const updateXAxisDomain = (config, input = {}) => {
-  config.axis.x.outlierStretchFactor = determineOutlierStretchFactorXAxis(config);
-  console.log(config.axis.x.outlierStretchFactor);
-
-
-  if (utils.isEmpty(input)) {
+const updateXAxisDomain = (config, input = {}) => {
+  if (utils.isEmpty(input) || !config.axis.x.allowCalibration) {
     return config;
   }
 
+  config.axis.x.outlierStretchFactor = determineOutlierStretchFactorXAxis(config);
+  console.log(config.axis.x.outlierStretchFactor);
 
-  console.log("x-axis lowerLimit: ", config.axis.x.domain.lowerLimit);
-  console.log("x-axis upperLimit: ", config.axis.x.domain.upperLimit);
+  console.log('x-axis lowerLimit: ', config.axis.x.domain.lowerLimit);
+  console.log('x-axis upperLimit: ', config.axis.x.domain.upperLimit);
 
-  if (config.axis.x.allowCalibration) {
-    config.axisPadding.x = false;
+  config.axisPadding.x = false;
 
+  const halfDomain = (config.axis.x.domain.upperLimit - config.axis.x.domain.lowerLimit) / 2;
+  const midPoint = (config.axis.x.domain.upperLimit + config.axis.x.domain.lowerLimit) / 2;
+  const newDomain = {
+    lowerLimit: midPoint - halfDomain * config.axis.x.outlierStretchFactor.lowerLimit,
+    upperLimit: midPoint + halfDomain * config.axis.x.outlierStretchFactor.upperLimit,
+  };
 
-    
-    const halfDomain = (config.axis.x.domain.upperLimit - config.axis.x.domain.lowerLimit) / 2;
-    const midPoint = (config.axis.x.domain.upperLimit + config.axis.x.domain.lowerLimit) / 2;
-    const newDomain = {
-                        lowerLimit: midPoint - halfDomain * config.axis.x.outlierStretchFactor.lowerLimit,
-                        upperLimit: midPoint + halfDomain * config.axis.x.outlierStretchFactor.upperLimit,
-                      };
+  config.axis.x.domain = padDomain(newDomain, config.axisPadding.x);
 
-    config.axis.x.domain = padDomain( newDomain, config.axisPadding.x);
-
-    console.log("x-axis domain: ", config.axis.x.domain)
-  }
+  console.log('x-axis domain: ', config.axis.x.domain);
   console.log(config.axisPadding);
 
   return config;
@@ -889,6 +868,9 @@ const determineHeight = (config, dimension) => {
   }
   const verticalPadding = config.padding.top + config.padding.bottom;
   const halfHeight = (DEFAULT_HEIGHT - verticalPadding) / 2;
+
+  config.outlierStretchFactor = determineOutlierStretchFactor(config);
+
   return (
     halfHeight * config.outlierStretchFactor.upperLimit
         + halfHeight * config.outlierStretchFactor.lowerLimit

--- a/packages/carbon-graphs/src/js/controls/Graph/helpers/helpers.js
+++ b/packages/carbon-graphs/src/js/controls/Graph/helpers/helpers.js
@@ -5,7 +5,7 @@ import { getScale } from '../../../core/BaseConfig/index';
 import {
   buildAxisLabel,
   calculateVerticalPadding,
-  determineOutlierStretchFactor,
+  determineOutlierStretchFactorYAxes,
   determineOutlierStretchFactorXAxis,
   getAxesScale,
   getRotationForAxis,
@@ -467,7 +467,7 @@ const updateAxesDomain = (config, input = {}) => {
     return config;
   }
 
-  config.outlierStretchFactor = determineOutlierStretchFactor(config);
+  config.outlierStretchFactor = determineOutlierStretchFactorYAxes(config);
 
   const yAxis = input.config.yAxis || constants.Y_AXIS;
 
@@ -859,7 +859,7 @@ const determineHeight = (config, dimension) => {
   const verticalPadding = config.padding.top + config.padding.bottom;
   const halfHeight = (DEFAULT_HEIGHT - verticalPadding) / 2;
 
-  config.outlierStretchFactor = determineOutlierStretchFactor(config);
+  config.outlierStretchFactor = determineOutlierStretchFactorYAxes(config);
 
   return (
     halfHeight * config.outlierStretchFactor.upperLimit

--- a/packages/carbon-graphs/src/js/controls/Graph/helpers/helpers.js
+++ b/packages/carbon-graphs/src/js/controls/Graph/helpers/helpers.js
@@ -2,7 +2,6 @@
 
 import * as d3 from 'd3';
 import { getScale, getDefaultValue } from '../../../core/BaseConfig/index';
-// import { getDefaultValue } from '../../core/BaseConfig';
 
 import {
   buildAxisLabel,

--- a/packages/carbon-graphs/src/js/controls/Line/Line.js
+++ b/packages/carbon-graphs/src/js/controls/Line/Line.js
@@ -298,10 +298,7 @@ class Line extends GraphContent {
         )
         .remove();
     }
-    this.valuesRange = calculateValuesRangeYAxis(
-      this.config.values,
-      this.config.yAxis,
-    );
+    this.valuesRange[this.config.yAxis] = calculateValuesRangeYAxis(this.config.values, this.config.yAxis);
   }
 
   /**

--- a/packages/carbon-graphs/src/js/controls/Line/Line.js
+++ b/packages/carbon-graphs/src/js/controls/Line/Line.js
@@ -52,8 +52,8 @@ import LineConfig from './LineConfig';
 const calculateValuesRangeYAxis = (values) => {
   const yAxisValuesList = values.filter((i) => i.y !== null && i.y !== undefined).map((i) => i.y);
   return {
-      min: Math.min(...yAxisValuesList),
-      max: Math.max(...yAxisValuesList),
+    min: Math.min(...yAxisValuesList),
+    max: Math.max(...yAxisValuesList),
   };
 };
 
@@ -72,12 +72,12 @@ const calculateValuesRangeYAxis = (values) => {
  * @param {Array} values - Datapoint values
  * @returns {object} - Contains min and max values for the data points for Y and Y2 axis
  */
- const calculateValuesRangeXAxis = (values) => {
+const calculateValuesRangeXAxis = (values) => {
   const xAxisValuesList = values.filter((i) => i.x !== null && i.x !== undefined).map((i) => i.x);
   // console.log(xAxisValuesList);
   return {
-      min: Math.min(...xAxisValuesList),
-      max: Math.max(...xAxisValuesList),
+    min: Math.min(...xAxisValuesList),
+    max: Math.max(...xAxisValuesList),
   };
 };
 

--- a/packages/carbon-graphs/src/js/controls/Line/Line.js
+++ b/packages/carbon-graphs/src/js/controls/Line/Line.js
@@ -74,7 +74,6 @@ const calculateValuesRangeYAxis = (values) => {
  */
 const calculateValuesRangeXAxis = (values) => {
   const xAxisValuesList = values.filter((i) => i.x !== null && i.x !== undefined).map((i) => i.x);
-  // console.log(xAxisValuesList);
   return {
     min: Math.min(...xAxisValuesList),
     max: Math.max(...xAxisValuesList),
@@ -126,7 +125,6 @@ class Line extends GraphContent {
     this.valuesRange.x = calculateValuesRangeXAxis(
       this.config.values,
     );
-    console.log(this.valuesRange);
     this.dataTarget = {};
   }
 

--- a/packages/carbon-graphs/src/js/controls/Line/Line.js
+++ b/packages/carbon-graphs/src/js/controls/Line/Line.js
@@ -63,7 +63,7 @@ const calculateValuesRangeYAxis = (values) => {
  * @typedef {object} LineConfig
  */
 /**
- * Calculates the min and max values for Y Axis or Y2 Axis.
+ * Calculates the min and max values for tje x-axis
  * First we filter out values that are `null`, this is a result of
  * datapoint being part of being in a non-contiguous series and then we
  * get the min and max values for the Y or Y2 axis domain.
@@ -119,12 +119,13 @@ class Line extends GraphContent {
     );
     this.valuesRange = {};
 
-    this.valuesRange[this.config.yAxis] = calculateValuesRangeYAxis(
-      this.config.values,
-    );
     this.valuesRange.x = calculateValuesRangeXAxis(
       this.config.values,
     );
+    this.valuesRange[this.config.yAxis] = calculateValuesRangeYAxis(
+      this.config.values,
+    );
+
     this.dataTarget = {};
   }
 

--- a/packages/carbon-graphs/src/js/controls/Line/Line.js
+++ b/packages/carbon-graphs/src/js/controls/Line/Line.js
@@ -47,16 +47,37 @@ import LineConfig from './LineConfig';
  *
  * @private
  * @param {Array} values - Datapoint values
- * @param {string} axis - y or y2
  * @returns {object} - Contains min and max values for the data points for Y and Y2 axis
  */
-const calculateValuesRange = (values, axis = constants.Y_AXIS) => {
+const calculateValuesRangeYAxis = (values) => {
   const yAxisValuesList = values.filter((i) => i.y !== null && i.y !== undefined).map((i) => i.y);
   return {
-    [axis]: {
       min: Math.min(...yAxisValuesList),
       max: Math.max(...yAxisValuesList),
-    },
+  };
+};
+
+/**
+ * @typedef {object} Line
+ * @typedef {object} GraphContent
+ * @typedef {object} LineConfig
+ */
+/**
+ * Calculates the min and max values for Y Axis or Y2 Axis.
+ * First we filter out values that are `null`, this is a result of
+ * datapoint being part of being in a non-contiguous series and then we
+ * get the min and max values for the Y or Y2 axis domain.
+ *
+ * @private
+ * @param {Array} values - Datapoint values
+ * @returns {object} - Contains min and max values for the data points for Y and Y2 axis
+ */
+ const calculateValuesRangeXAxis = (values) => {
+  const xAxisValuesList = values.filter((i) => i.x !== null && i.x !== undefined).map((i) => i.x);
+  // console.log(xAxisValuesList);
+  return {
+      min: Math.min(...xAxisValuesList),
+      max: Math.max(...xAxisValuesList),
   };
 };
 
@@ -97,10 +118,15 @@ class Line extends GraphContent {
       this.config.yAxis,
       constants.Y_AXIS,
     );
-    this.valuesRange = calculateValuesRange(
+    this.valuesRange = {};
+
+    this.valuesRange[this.config.yAxis] = calculateValuesRangeYAxis(
       this.config.values,
-      this.config.yAxis,
     );
+    this.valuesRange.x = calculateValuesRangeXAxis(
+      this.config.values,
+    );
+    console.log(this.valuesRange);
     this.dataTarget = {};
   }
 
@@ -274,7 +300,7 @@ class Line extends GraphContent {
         )
         .remove();
     }
-    this.valuesRange = calculateValuesRange(
+    this.valuesRange = calculateValuesRangeYAxis(
       this.config.values,
       this.config.yAxis,
     );

--- a/packages/carbon-graphs/src/js/controls/Timeline/Timeline.js
+++ b/packages/carbon-graphs/src/js/controls/Timeline/Timeline.js
@@ -2,7 +2,7 @@
 
 import * as d3 from 'd3';
 import Construct from '../../core/Construct';
-import { getYAxisHeight, updateXAxisDomain } from '../../helpers/axis';
+import { getYAxisHeight, setXAxisDomain } from '../../helpers/axis';
 import constants from '../../helpers/constants';
 import errors from '../../helpers/errors';
 import { createLegend, reflowLegend } from '../../helpers/legend';
@@ -336,7 +336,7 @@ class Timeline extends Construct {
       clickHandler: clickHandler(this, this, this.config, this.svg),
       hoverHandler: hoverHandler(this.config.shownTargets, this.svg),
     };
-    updateXAxisDomain(this.config);
+    setXAxisDomain(this.config);
     scaleGraph(this.scale, this.config);
     translateAxes(this.axis, this.scale, this.config, this.svg);
     if (

--- a/packages/carbon-graphs/src/js/controls/Timeline/Timeline.js
+++ b/packages/carbon-graphs/src/js/controls/Timeline/Timeline.js
@@ -301,7 +301,7 @@ class Timeline extends Construct {
       clickHandler: clickHandler(this, this, this.config, this.svg),
       hoverHandler: hoverHandler(this.config.shownTargets, this.svg),
     };
-    updateXAxisDomain(this.config);
+    setXAxisDomain(this.config);
     scaleGraph(this.scale, this.config);
     translateAxes(this.axis, this.scale, this.config, this.svg);
     if (

--- a/packages/carbon-graphs/src/js/helpers/axis.js
+++ b/packages/carbon-graphs/src/js/helpers/axis.js
@@ -1312,27 +1312,36 @@ const getMidPoint = (config, axis) => {
  */
 // eslint-disable-next-line no-unused-vars
 const getLowerOutlierStretchFactorXAxis = (config) => {
-  const lowerStretchFactors = [];
-  const getMinValue = (conf, xAxis, axisMinValue) => {
-    const dataRangeMinValue = conf.axis[xAxis].dataRange.min;
-    return dataRangeMinValue < axisMinValue
-      ? dataRangeMinValue
-      : axisMinValue;
-  };
-  const getLowerStretchFactor = (xAxis) => {
-    const axisMinValue = config.axis[xAxis].domain.lowerLimit;
-    const axisMidPoint = getMidPoint(config, xAxis);
-    const lowerStretchFactor = Math.abs(
-      (axisMidPoint - getMinValue(config, xAxis, axisMinValue))
-                / (axisMidPoint - axisMinValue),
-    );
-    return lowerStretchFactor > 1 ? lowerStretchFactor : 1;
-  };
-  lowerStretchFactors.push(getLowerStretchFactor(constants.X_AXIS));
-  console.log("lower stretch factor: ");
-  console.log(lowerStretchFactors);
+  // const lowerStretchFactors = [];
+  // const getMinValue = (conf, xAxis, axisMinValue) => {
+  //   const dataRangeMinValue = conf.axis[xAxis].dataRange.min;
+  //   return dataRangeMinValue < axisMinValue
+  //     ? dataRangeMinValue
+  //     : axisMinValue;
+  // };
+  // const getLowerStretchFactor = (xAxis) => {
+  //   const axisMinValue = config.axis[xAxis].domain.lowerLimit;
+  //   const axisMidPoint = getMidPoint(config, xAxis);
+  //   const lowerStretchFactor = Math.abs(
+  //     (axisMidPoint - getMinValue(config, xAxis, axisMinValue))
+  //               / (axisMidPoint - axisMinValue),
+  //   );
+  //   return lowerStretchFactor > 1 ? lowerStretchFactor : 1;
+  // };
+  // lowerStretchFactors.push(getLowerStretchFactor(constants.X_AXIS));
+  // console.log('lower stretch factor: ');
+  // console.log(lowerStretchFactors);
 
-  return lowerStretchFactors;
+  // return lowerStretchFactors;
+
+  const axisMinValue = config.axis.x.domain.lowerLimit;
+  const dataRangeMinValue = config.axis.x.dataRange.min < axisMinValue ? conf.axis.x.dataRange.min : axisMinValue;
+  const axisMidPoint = getMidPoint(config, constants.X_AXIS);
+  const lowerStretchFactor = Math.abs((axisMidPoint - dataRangeMinValue) / (axisMidPoint - axisMinValue));
+  
+  console.log('lower stretch factor: ', lowerStretchFactor);
+
+  return lowerStretchFactor > 1 ? lowerStretchFactor : 1;
 };
 
 /**
@@ -1369,6 +1378,23 @@ const getLowerOutlierStretchFactorList = (config) => {
 };
 
 /**
+ * Calculates the lower part of the outlier based on data points.
+ * If the content has any data points that are outside the lower and upper bounds set
+ * in the vertical axis then we adjust the axis bounds to support that outlier value.
+ *
+ * @private
+ * @param {object} config - config object derived from input JSON
+ * @returns {Array} List of lower bound values for each of the vertical axis
+ */
+const getLowerStretchFactorYAxis = (config, yAxis) => {
+  const axisMinValue = config.axis[yAxis].domain.lowerLimit;
+  const dataRangeMinValue = config.axis[yAxis].dataRange.min < axisMinValue ? config.axis[yAxis].dataRange.min : axisMinValue;
+  const axisMidPoint = getMidPoint(config, yAxis);
+  const lowerStretchFactor = Math.abs((axisMidPoint - dataRangeMinValue) / (axisMidPoint - axisMinValue));
+  return lowerStretchFactor > 1 ? lowerStretchFactor : 1;
+};
+
+/**
  * Updates the x axis domain values.
  *
  * @private
@@ -1392,21 +1418,28 @@ const setXAxisDomain = (config) => {
  */
 const getUpperOutlierStretchFactorList = (config) => {
   const upperStretchFactors = [];
-  const getMaxValue = (conf, yAxis, axisMaxValue) => {
-    const dataRangeMaxValue = conf.axis[yAxis].dataRange.max;
-    return dataRangeMaxValue > axisMaxValue
-      ? dataRangeMaxValue
-      : axisMaxValue;
-  };
+
+  // const getMaxValue = (conf, yAxis, axisMaxValue) => {
+  //   const dataRangeMaxValue = conf.axis[yAxis].dataRange.max;
+  //   return dataRangeMaxValue > axisMaxValue
+  //     ? dataRangeMaxValue
+  //     : axisMaxValue;
+  // };
+
   const getUpperStretchFactor = (yAxis) => {
+
     const axisMaxValue = config.axis[yAxis].domain.upperLimit;
+
+    const dataRangeMaxValue = config.axis[yAxis].dataRange.max > axisMaxValue ? config.axis[yAxis].dataRange.max: axisMaxValue;
+
     const axisMidPoint = getMidPoint(config, yAxis);
     const upperStretchFactor = Math.abs(
-      (getMaxValue(config, yAxis, axisMaxValue) - axisMidPoint)
+      (dataRangeMaxValue - axisMidPoint)
                 / (axisMaxValue - axisMidPoint),
     );
     return upperStretchFactor > 1 ? upperStretchFactor : 1;
   };
+
   upperStretchFactors.push(getUpperStretchFactor(constants.Y_AXIS));
   if (hasY2Axis(config.axis)) {
     upperStretchFactors.push(getUpperStretchFactor(constants.Y2_AXIS));
@@ -1421,29 +1454,54 @@ const getUpperOutlierStretchFactorList = (config) => {
  *
  * @private
  * @param {object} config - config object derived from input JSON
- * @returns {Array} List of upper bound values for each of the vertical axis
+ * @returns {number} upper bound value for of the input vertical axis
+ */
+
+const getUpperStretchFactorYAxis = (config, yAxis) => {
+
+  const axisMaxValue = config.axis[yAxis].domain.upperLimit;
+  const dataRangeMaxValue = config.axis[yAxis].dataRange.max > axisMaxValue ? config.axis[yAxis].dataRange.max: axisMaxValue;
+  const axisMidPoint = getMidPoint(config, yAxis);
+  const upperStretchFactor = Math.abs((dataRangeMaxValue - axisMidPoint) / (axisMaxValue - axisMidPoint));
+  return upperStretchFactor > 1 ? upperStretchFactor : 1;
+};
+
+/**
+ * Calculates the upper part of the outlier based on data points.
+ * If the content has any data points that are outside the lower and upper bounds set
+ * in the vertical axis then we adjust the axis bounds to support that outlier value.
+ *
+ * @private
+ * @param {object} config - config object derived from input JSON
+ * @returns {number} List of upper bound values for each of the vertical axis
  */
 const getUpperOutlierStretchFactorXAxis = (config) => {
-  const upperStretchFactors = [];
-  const getMaxValue = (conf, xAxis, axisMaxValue) => {
-    const dataRangeMaxValue = conf.axis.x.dataRange.max;
-    console.log(dataRangeMaxValue);
-    return dataRangeMaxValue > axisMaxValue
-      ? dataRangeMaxValue
-      : axisMaxValue;
-  };
-  const getUpperStretchFactor = (xAxis) => {
-    const axisMaxValue = config.axis[xAxis].domain.upperLimit;
-    const axisMidPoint = getMidPoint(config, xAxis);
-    const upperStretchFactor = Math.abs(
-      (getMaxValue(config, xAxis, axisMaxValue) - axisMidPoint)
-                / (axisMaxValue - axisMidPoint),
-    );
-    return upperStretchFactor > 1 ? upperStretchFactor : 1;
-  };
-  upperStretchFactors.push(getUpperStretchFactor(constants.X_AXIS));
+  // const upperStretchFactors = [];
+  // const getMaxValue = (conf, xAxis, axisMaxValue) => {
+  //   const dataRangeMaxValue = conf.axis.x.dataRange.max;
+  //   console.log(dataRangeMaxValue);
+  //   return dataRangeMaxValue > axisMaxValue
+  //     ? dataRangeMaxValue
+  //     : axisMaxValue;
+  // };
+  // const getUpperStretchFactor = (xAxis) => {
+  //   const axisMaxValue = config.axis[xAxis].domain.upperLimit;
+  //   const axisMidPoint = getMidPoint(config, xAxis);
+  //   const upperStretchFactor = Math.abs(
+  //     (getMaxValue(config, xAxis, axisMaxValue) - axisMidPoint)
+  //               / (axisMaxValue - axisMidPoint),
+  //   );
+  //   return upperStretchFactor > 1 ? upperStretchFactor : 1;
+  // };
+  // upperStretchFactors.push(getUpperStretchFactor(constants.X_AXIS));
 
-  return upperStretchFactors;
+  // return upperStretchFactors;
+
+  const axisMaxValue = config.axis.x.domain.upperLimit;
+  const dataRangeMaxValue = config.axis.x.dataRange.max > axisMaxValue ? config.axis.x.dataRange.max: axisMaxValue;
+  const axisMidPoint = getMidPoint(config, constants.X_AXIS);
+  const upperStretchFactor = Math.abs((dataRangeMaxValue - axisMidPoint) / (axisMaxValue - axisMidPoint));
+  return upperStretchFactor > 1 ? upperStretchFactor : 1;
 };
 
 /**
@@ -1457,15 +1515,31 @@ const getUpperOutlierStretchFactorXAxis = (config) => {
 */
 //
 const determineOutlierStretchFactorXAxis = (config) => {
+
+
   const sortOutlier = (firstValue, secondValue) => secondValue - firstValue;
-  return {
-    upperLimit: getUpperOutlierStretchFactorXAxis(config).sort(
-      sortOutlier,
-    )[0],
-    lowerLimit: getLowerOutlierStretchFactorXAxis(config).sort(
-      sortOutlier,
-    )[0],
-  };
+  let stretchFactors = {};
+
+  const upperStretchFactors = [];
+  const lowerStretchFactors = [];
+
+  upperStretchFactors.push(getUpperOutlierStretchFactorXAxis(config));
+  lowerStretchFactors.push(getLowerOutlierStretchFactorXAxis(config));
+
+  stretchFactors.upperLimit = upperStretchFactors.sort(sortOutlier)[0];
+  stretchFactors.lowerLimit = lowerStretchFactors.sort(sortOutlier)[0];
+  
+  return stretchFactors;
+
+  // return {
+  //   upperLimit: getUpperOutlierStretchFactorXAxis(config).sort(
+  //     sortOutlier,
+  //   )[0],
+  //   lowerLimit: getLowerOutlierStretchFactorXAxis(config).sort(
+  //     sortOutlier,
+  //   )[0],
+  // };
+
 };
 
 /**
@@ -1479,14 +1553,32 @@ const determineOutlierStretchFactorXAxis = (config) => {
  */
 const determineOutlierStretchFactor = (config) => {
   const sortOutlier = (firstValue, secondValue) => secondValue - firstValue;
-  return {
-    upperLimit: getUpperOutlierStretchFactorList(config).sort(
-      sortOutlier,
-    )[0],
-    lowerLimit: getLowerOutlierStretchFactorList(config).sort(
-      sortOutlier,
-    )[0],
-  };
+  let stretchFactors = {};
+
+  const upperStretchFactors = [];
+  const lowerStretchFactors = [];
+
+  upperStretchFactors.push(getUpperStretchFactorYAxis(config, constants.Y_AXIS));
+  lowerStretchFactors.push(getLowerStretchFactorYAxis(config, constants.Y_AXIS));
+
+  if (hasY2Axis(config.axis)) {
+    upperStretchFactors.push(getUpperStretchFactorYAxis(config, constants.Y2_AXIS));
+    lowerStretchFactors.push(getLowerStretchFactorYAxis(config, constants.Y2_AXIS));
+  }
+
+  stretchFactors.upperLimit = upperStretchFactors.sort(sortOutlier)[0];
+  stretchFactors.lowerLimit = lowerStretchFactors.sort(sortOutlier)[0];
+  
+  return stretchFactors;
+
+  // return {
+  //   upperLimit: getUpperOutlierStretchFactorList(config).sort(
+  //     sortOutlier,
+  //   )[0],
+  //   lowerLimit: getLowerOutlierStretchFactorList(config).sort(
+  //     sortOutlier,
+  //   )[0],
+  // };
 };
 
 /**
@@ -1601,6 +1693,9 @@ const translateAxisReferenceLine = (axis, scale, config, canvasSVG) => {
  * @returns {object} - Object with min and max value ranges
  */
 const getCurMinMaxValueRange = (input, content, axis) => {
+  console.log('getCurMinMaxValueRange - input.valueRange: ', input.valuesRange);
+  console.log(axis);
+
   if (input instanceof Bar) {
     let min = 0;
     let max = 0;
@@ -1644,7 +1739,8 @@ const getAxesDataRange = (
   config,
   content = [],
 ) => {
-  console.log(axis);
+  console.log('axis ', axis);
+
   if (utils.isEmpty(config.axis.x.dataRange)) {
     config.axis.x.dataRange = {};
   }
@@ -1654,26 +1750,33 @@ const getAxesDataRange = (
   if (hasY2Axis(config.axis) && utils.isEmpty(config.axis.y2.dataRange)) {
     config.axis.y2.dataRange = {};
   }
-  console.log("input.valuesRange");
 
-  console.log(input.valuesRange);
+  console.log('input.valuesRange', input.valuesRange);
+
   if (utils.isEmpty(input) || utils.isEmpty(input.valuesRange)) {
     return;
   }
+
   const curRange = getCurMinMaxValueRange(input, content, axis);
-  console.log(curRange)
+
+  console.log('curRange: ', curRange);
+
   const prevMin = config.axis[axis].dataRange.oldMin;
   const prevMax = config.axis[axis].dataRange.oldMax;
   let isRangeModified;
+
   if (prevMin === 0) {
     isRangeModified = !(prevMin <= curRange.min || prevMax >= curRange.max);
   } else {
     isRangeModified = !(prevMin && prevMax)
         || !(prevMin <= curRange.min || prevMax >= curRange.max);
   }
-  console.log(isRangeModified);
+
   config.axis[axis].dataRange.isRangeModified = isRangeModified;
-  console.log(config.axis[axis].dataRange);
+
+  console.log('isRangeModified ', isRangeModified);
+  console.log('dataRange ', config.axis[axis].dataRange);
+
   if (isRangeModified) {
     config.axis[axis].dataRange.oldMin = config.axis[axis].dataRange.min;
     config.axis[axis].dataRange.oldMax = config.axis[axis].dataRange.max;

--- a/packages/carbon-graphs/src/js/helpers/axis.js
+++ b/packages/carbon-graphs/src/js/helpers/axis.js
@@ -1339,8 +1339,6 @@ const getLowerOutlierStretchFactorXAxis = (config) => {
   const axisMidPoint = getMidPoint(config, constants.X_AXIS);
   const lowerStretchFactor = Math.abs((axisMidPoint - dataRangeMinValue) / (axisMidPoint - axisMinValue));
   
-  console.log('lower stretch factor: ', lowerStretchFactor);
-
   return lowerStretchFactor > 1 ? lowerStretchFactor : 1;
 };
 
@@ -1516,29 +1514,13 @@ const getUpperOutlierStretchFactorXAxis = (config) => {
 //
 const determineOutlierStretchFactorXAxis = (config) => {
 
-
   const sortOutlier = (firstValue, secondValue) => secondValue - firstValue;
   let stretchFactors = {};
 
-  const upperStretchFactors = [];
-  const lowerStretchFactors = [];
+  stretchFactors.upperLimit = getUpperOutlierStretchFactorXAxis(config);
+  stretchFactors.lowerLimit = getLowerOutlierStretchFactorXAxis(config);
 
-  upperStretchFactors.push(getUpperOutlierStretchFactorXAxis(config));
-  lowerStretchFactors.push(getLowerOutlierStretchFactorXAxis(config));
-
-  stretchFactors.upperLimit = upperStretchFactors.sort(sortOutlier)[0];
-  stretchFactors.lowerLimit = lowerStretchFactors.sort(sortOutlier)[0];
-  
   return stretchFactors;
-
-  // return {
-  //   upperLimit: getUpperOutlierStretchFactorXAxis(config).sort(
-  //     sortOutlier,
-  //   )[0],
-  //   lowerLimit: getLowerOutlierStretchFactorXAxis(config).sort(
-  //     sortOutlier,
-  //   )[0],
-  // };
 
 };
 
@@ -1558,16 +1540,32 @@ const determineOutlierStretchFactor = (config) => {
   const upperStretchFactors = [];
   const lowerStretchFactors = [];
 
-  upperStretchFactors.push(getUpperStretchFactorYAxis(config, constants.Y_AXIS));
-  lowerStretchFactors.push(getLowerStretchFactorYAxis(config, constants.Y_AXIS));
+  stretchFactors.upperLimit = getUpperStretchFactorYAxis(config, constants.Y_AXIS);
+  stretchFactors.lowerLimit = getLowerStretchFactorYAxis(config, constants.Y_AXIS);
+
+  upperStretchFactors.push(stretchFactors.upperLimit);
+  lowerStretchFactors.push(stretchFactors.lowerLimit);
+
+
 
   if (hasY2Axis(config.axis)) {
     upperStretchFactors.push(getUpperStretchFactorYAxis(config, constants.Y2_AXIS));
     lowerStretchFactors.push(getLowerStretchFactorYAxis(config, constants.Y2_AXIS));
+
+    let upperLimitY2 = getUpperStretchFactorYAxis(config, constants.Y2_AXIS);
+    let lowerLimitY2 = getLowerStretchFactorYAxis(config, constants.Y2_AXIS);
+
+    stretchFactors.upperLimit = upperLimitY2 > stretchFactors.upperLimit ? upperLimitY2 : stretchFactors.upperLimit;
+    stretchFactors.lowerLimit = lowerLimitY2 > stretchFactors.lowerLimit ? lowerLimitY2 : stretchFactors.lowerLimit;
   }
 
-  stretchFactors.upperLimit = upperStretchFactors.sort(sortOutlier)[0];
-  stretchFactors.lowerLimit = lowerStretchFactors.sort(sortOutlier)[0];
+  // console.log(lowerStretchFactors);
+
+
+  // stretchFactors.upperLimit = upperStretchFactors.sort(sortOutlier)[0];
+  // stretchFactors.lowerLimit = lowerStretchFactors.sort(sortOutlier)[0];
+
+  // console.log(stretchFactors);
   
   return stretchFactors;
 
@@ -1693,8 +1691,6 @@ const translateAxisReferenceLine = (axis, scale, config, canvasSVG) => {
  * @returns {object} - Object with min and max value ranges
  */
 const getCurMinMaxValueRange = (input, content, axis) => {
-  console.log('getCurMinMaxValueRange - input.valueRange: ', input.valuesRange);
-  console.log(axis);
 
   if (input instanceof Bar) {
     let min = 0;
@@ -1739,7 +1735,6 @@ const getAxesDataRange = (
   config,
   content = [],
 ) => {
-  console.log('axis ', axis);
 
   if (utils.isEmpty(config.axis.x.dataRange)) {
     config.axis.x.dataRange = {};
@@ -1751,7 +1746,6 @@ const getAxesDataRange = (
     config.axis.y2.dataRange = {};
   }
 
-  console.log('input.valuesRange', input.valuesRange);
 
   if (utils.isEmpty(input) || utils.isEmpty(input.valuesRange)) {
     return;
@@ -1759,7 +1753,6 @@ const getAxesDataRange = (
 
   const curRange = getCurMinMaxValueRange(input, content, axis);
 
-  console.log('curRange: ', curRange);
 
   const prevMin = config.axis[axis].dataRange.oldMin;
   const prevMax = config.axis[axis].dataRange.oldMax;
@@ -1773,9 +1766,6 @@ const getAxesDataRange = (
   }
 
   config.axis[axis].dataRange.isRangeModified = isRangeModified;
-
-  console.log('isRangeModified ', isRangeModified);
-  console.log('dataRange ', config.axis[axis].dataRange);
 
   if (isRangeModified) {
     config.axis[axis].dataRange.oldMin = config.axis[axis].dataRange.min;

--- a/packages/carbon-graphs/src/js/helpers/axis.js
+++ b/packages/carbon-graphs/src/js/helpers/axis.js
@@ -1307,7 +1307,7 @@ const getMidPoint = (config, axis) => {
  * @private
  * @param {object} config - config object derived from input JSON
  */
- const setXAxisDomain = (config) => {
+const setXAxisDomain = (config) => {
   config.axis.x.domain = getXAxisDomain(
     config.axis.x.type,
     config.axis.x.lowerLimit,
@@ -1326,9 +1326,9 @@ const getMidPoint = (config, axis) => {
  * @returns {number} the stretch factor for the new upper limit
  */
 
- const getUpperOutlierStretchFactor = (config, axis) => {
+const getUpperOutlierStretchFactor = (config, axis) => {
   const axisMaxValue = config.axis[axis].domain.upperLimit;
-  const dataRangeMaxValue = config.axis[axis].dataRange.max > axisMaxValue ? config.axis[axis].dataRange.max: axisMaxValue;
+  const dataRangeMaxValue = config.axis[axis].dataRange.max > axisMaxValue ? config.axis[axis].dataRange.max : axisMaxValue;
   const axisMidPoint = getMidPoint(config, axis);
   const upperStretchFactor = Math.abs((dataRangeMaxValue - axisMidPoint) / (axisMaxValue - axisMidPoint));
   return upperStretchFactor > 1 ? upperStretchFactor : 1;
@@ -1345,12 +1345,11 @@ const getMidPoint = (config, axis) => {
  * @returns {number} the stretch factor for the new lower limit
  */
 const getLowerOutlierStretchFactor = (config, axis) => {
-
   const axisMinValue = config.axis[axis].domain.lowerLimit;
   const dataRangeMinValue = config.axis[axis].dataRange.min < axisMinValue ? config.axis[axis].dataRange.min : axisMinValue;
   const axisMidPoint = getMidPoint(config, axis);
   const lowerStretchFactor = Math.abs((axisMidPoint - dataRangeMinValue) / (axisMidPoint - axisMinValue));
-  
+
   return lowerStretchFactor > 1 ? lowerStretchFactor : 1;
 };
 
@@ -1363,8 +1362,7 @@ const getLowerOutlierStretchFactor = (config, axis) => {
 * @returns {object} stretch factor that determines the new upper and lower limit of the x-axis
 */
 const determineOutlierStretchFactorXAxis = (config) => {
-
-  let stretchFactors = {};
+  const stretchFactors = {};
 
   stretchFactors.upperLimit = getUpperOutlierStretchFactor(config, constants.X_AXIS);
   stretchFactors.lowerLimit = getLowerOutlierStretchFactor(config, constants.X_AXIS);
@@ -1381,20 +1379,19 @@ const determineOutlierStretchFactorXAxis = (config) => {
  * @returns {object} stretch factor determines the new upper and lower limit of the vertical axes
  */
 const determineOutlierStretchFactorYAxes = (config) => {
-  let stretchFactors = {};
+  const stretchFactors = {};
 
   stretchFactors.upperLimit = getUpperOutlierStretchFactor(config, constants.Y_AXIS);
   stretchFactors.lowerLimit = getLowerOutlierStretchFactor(config, constants.Y_AXIS);
 
   if (hasY2Axis(config.axis)) {
-
-    let upperLimitY2 = getUpperOutlierStretchFactor(config, constants.Y2_AXIS);
-    let lowerLimitY2 = getLowerOutlierStretchFactor(config, constants.Y2_AXIS);
+    const upperLimitY2 = getUpperOutlierStretchFactor(config, constants.Y2_AXIS);
+    const lowerLimitY2 = getLowerOutlierStretchFactor(config, constants.Y2_AXIS);
 
     stretchFactors.upperLimit = upperLimitY2 > stretchFactors.upperLimit ? upperLimitY2 : stretchFactors.upperLimit;
     stretchFactors.lowerLimit = lowerLimitY2 > stretchFactors.lowerLimit ? lowerLimitY2 : stretchFactors.lowerLimit;
   }
-  
+
   return stretchFactors;
 };
 
@@ -1553,7 +1550,6 @@ const getAxesDataRange = (
   config,
   content = [],
 ) => {
-
   if (utils.isEmpty(config.axis.x.dataRange)) {
     config.axis.x.dataRange = {};
   }
@@ -1564,13 +1560,11 @@ const getAxesDataRange = (
     config.axis.y2.dataRange = {};
   }
 
-
   if (utils.isEmpty(input) || utils.isEmpty(input.valuesRange)) {
     return;
   }
 
   const curRange = getCurMinMaxValueRange(input, content, axis);
-
 
   const prevMin = config.axis[axis].dataRange.oldMin;
   const prevMax = config.axis[axis].dataRange.oldMax;

--- a/packages/carbon-graphs/src/js/helpers/axis.js
+++ b/packages/carbon-graphs/src/js/helpers/axis.js
@@ -1331,7 +1331,7 @@ const getUpperOutlierStretchFactor = (config, axis) => {
   const dataRangeMaxValue = config.axis[axis].dataRange.max > axisMaxValue ? config.axis[axis].dataRange.max : axisMaxValue;
   const axisMidPoint = getMidPoint(config, axis);
   const upperStretchFactor = Math.abs((dataRangeMaxValue - axisMidPoint) / (axisMaxValue - axisMidPoint));
-  
+
   // console.log(upperStretchFactor);
 
   return upperStretchFactor > 1 ? upperStretchFactor : 1;

--- a/packages/carbon-graphs/src/js/helpers/axis.js
+++ b/packages/carbon-graphs/src/js/helpers/axis.js
@@ -1329,6 +1329,8 @@ const getLowerOutlierStretchFactorXAxis = (config) => {
     return lowerStretchFactor > 1 ? lowerStretchFactor : 1;
   };
   lowerStretchFactors.push(getLowerStretchFactor(constants.X_AXIS));
+  console.log("lower stretch factor: ");
+  console.log(lowerStretchFactors);
 
   return lowerStretchFactors;
 };
@@ -1372,7 +1374,7 @@ const getLowerOutlierStretchFactorList = (config) => {
  * @private
  * @param {object} config - config object derived from input JSON
  */
-const updateXAxisDomain = (config) => {
+const setXAxisDomain = (config) => {
   config.axis.x.domain = getXAxisDomain(
     config.axis.x.type,
     config.axis.x.lowerLimit,
@@ -1424,7 +1426,8 @@ const getUpperOutlierStretchFactorList = (config) => {
 const getUpperOutlierStretchFactorXAxis = (config) => {
   const upperStretchFactors = [];
   const getMaxValue = (conf, xAxis, axisMaxValue) => {
-    const dataRangeMaxValue = conf.axis[xAxis].dataRange.max;
+    const dataRangeMaxValue = conf.axis.x.dataRange.max;
+    console.log(dataRangeMaxValue);
     return dataRangeMaxValue > axisMaxValue
       ? dataRangeMaxValue
       : axisMaxValue;
@@ -1459,7 +1462,7 @@ const determineOutlierStretchFactorXAxis = (config) => {
     upperLimit: getUpperOutlierStretchFactorXAxis(config).sort(
       sortOutlier,
     )[0],
-    lowerLimit: getLowerOutlierStretchFactorList(config).sort(
+    lowerLimit: getLowerOutlierStretchFactorXAxis(config).sort(
       sortOutlier,
     )[0],
   };
@@ -1641,6 +1644,7 @@ const getAxesDataRange = (
   config,
   content = [],
 ) => {
+  console.log(axis);
   if (utils.isEmpty(config.axis.x.dataRange)) {
     config.axis.x.dataRange = {};
   }
@@ -1650,10 +1654,14 @@ const getAxesDataRange = (
   if (hasY2Axis(config.axis) && utils.isEmpty(config.axis.y2.dataRange)) {
     config.axis.y2.dataRange = {};
   }
+  console.log("input.valuesRange");
+
+  console.log(input.valuesRange);
   if (utils.isEmpty(input) || utils.isEmpty(input.valuesRange)) {
     return;
   }
   const curRange = getCurMinMaxValueRange(input, content, axis);
+  console.log(curRange)
   const prevMin = config.axis[axis].dataRange.oldMin;
   const prevMax = config.axis[axis].dataRange.oldMax;
   let isRangeModified;
@@ -1663,7 +1671,9 @@ const getAxesDataRange = (
     isRangeModified = !(prevMin && prevMax)
         || !(prevMin <= curRange.min || prevMax >= curRange.max);
   }
+  console.log(isRangeModified);
   config.axis[axis].dataRange.isRangeModified = isRangeModified;
+  console.log(config.axis[axis].dataRange);
   if (isRangeModified) {
     config.axis[axis].dataRange.oldMin = config.axis[axis].dataRange.min;
     config.axis[axis].dataRange.oldMax = config.axis[axis].dataRange.max;
@@ -1737,7 +1747,7 @@ export {
   calculateVerticalPadding,
   isXAxisOrientationTop,
   getAxisInfoRowYPosition,
-  updateXAxisDomain,
+  setXAxisDomain,
   getTicksCountFromRange,
   getAverageTicksCount,
   formatLabel,

--- a/packages/carbon-graphs/src/js/helpers/axis.js
+++ b/packages/carbon-graphs/src/js/helpers/axis.js
@@ -1317,12 +1317,13 @@ const getMidPoint = (config, axis) => {
 
 /**
  * Calculates the upper part of the outlier based on data points.
- * If the content has any data points that are outside the lower and upper bounds set
- * in the vertical axis then we adjust the axis bounds to support that outlier value.
+ * If the input dataset has any data points that are outside the lower bound
+ * of the given axis, then the factor to adjust the upper limit by is calculated
  *
  * @private
  * @param {object} config - config object derived from input JSON
- * @returns {number} upper bound value for of the input vertical axis
+ * @param {string} axis - the axis to calculate the new stretch factor for
+ * @returns {number} the stretch factor for the new upper limit
  */
 
  const getUpperOutlierStretchFactor = (config, axis) => {
@@ -1335,14 +1336,14 @@ const getMidPoint = (config, axis) => {
 
 /**
  * Calculates the lower part of the outlier based on data points.
- * If the content has any data points that are outside the lower and upper bounds set
- * in the vertical axis then we adjust the axis bounds to support that outlier value.
+ * If the input dataset has any data points that are outside the lower bound
+ * of the given axis, then the factor to adjust the lowerlimit by is calculated
  *
  * @private
  * @param {object} config - config object derived from input JSON
- * @returns {Array} List of lower bound values for each of the vertical axis
+ * @param {string} axis - the axis to calculate the new stretch factor for
+ * @returns {number} the stretch factor for the new lower limit
  */
-// eslint-disable-next-line no-unused-vars
 const getLowerOutlierStretchFactor = (config, axis) => {
 
   const axisMinValue = config.axis[axis].domain.lowerLimit;
@@ -1354,13 +1355,12 @@ const getLowerOutlierStretchFactor = (config, axis) => {
 };
 
 /**
-* Determines if the values provided exceed the lower and upper bounds provided in the Y or Y2 axes
+* Determines if the values provided exceed the lower and upper bounds for a numerical x-axis
 * If the values exceed the bounds then the range and domain are adjusted accordingly.
-* There is no outlier check for X axis, for now, due to the possibility that X axis can be a timeseries.
 *
 * @private
 * @param {object} config - config object derived from input JSON
-* @returns {object} stretch factor determines the new upper and lower limit.
+* @returns {object} stretch factor that determines the new upper and lower limit of the x-axis
 */
 const determineOutlierStretchFactorXAxis = (config) => {
 
@@ -1370,17 +1370,15 @@ const determineOutlierStretchFactorXAxis = (config) => {
   stretchFactors.lowerLimit = getLowerOutlierStretchFactor(config, constants.X_AXIS);
 
   return stretchFactors;
-
 };
 
 /**
  * Determines if the values provided exceed the lower and upper bounds provided in the Y or Y2 axes
  * If the values exceed the bounds then the range and domain are adjusted accordingly.
- * There is no outlier check for X axis, for now, due to the possibility that X axis can be a timeseries.
  *
  * @private
  * @param {object} config - config object derived from input JSON
- * @returns {object} stretch factor determines the new upper and lower limit.
+ * @returns {object} stretch factor determines the new upper and lower limit of the vertical axes
  */
 const determineOutlierStretchFactorYAxes = (config) => {
   let stretchFactors = {};

--- a/packages/carbon-graphs/src/js/helpers/axis.js
+++ b/packages/carbon-graphs/src/js/helpers/axis.js
@@ -1691,7 +1691,6 @@ const translateAxisReferenceLine = (axis, scale, config, canvasSVG) => {
  * @returns {object} - Object with min and max value ranges
  */
 const getCurMinMaxValueRange = (input, content, axis) => {
-
   if (input instanceof Bar) {
     let min = 0;
     let max = 0;

--- a/packages/carbon-graphs/src/js/helpers/axis.js
+++ b/packages/carbon-graphs/src/js/helpers/axis.js
@@ -1302,147 +1302,17 @@ const getMidPoint = (config, axis) => {
 };
 
 /**
- * Calculates the lower part of the outlier based on data points.
- * If the content has any data points that are outside the lower and upper bounds set
- * in the vertical axis then we adjust the axis bounds to support that outlier value.
- *
- * @private
- * @param {object} config - config object derived from input JSON
- * @returns {Array} List of lower bound values for each of the vertical axis
- */
-// eslint-disable-next-line no-unused-vars
-const getLowerOutlierStretchFactorXAxis = (config) => {
-  // const lowerStretchFactors = [];
-  // const getMinValue = (conf, xAxis, axisMinValue) => {
-  //   const dataRangeMinValue = conf.axis[xAxis].dataRange.min;
-  //   return dataRangeMinValue < axisMinValue
-  //     ? dataRangeMinValue
-  //     : axisMinValue;
-  // };
-  // const getLowerStretchFactor = (xAxis) => {
-  //   const axisMinValue = config.axis[xAxis].domain.lowerLimit;
-  //   const axisMidPoint = getMidPoint(config, xAxis);
-  //   const lowerStretchFactor = Math.abs(
-  //     (axisMidPoint - getMinValue(config, xAxis, axisMinValue))
-  //               / (axisMidPoint - axisMinValue),
-  //   );
-  //   return lowerStretchFactor > 1 ? lowerStretchFactor : 1;
-  // };
-  // lowerStretchFactors.push(getLowerStretchFactor(constants.X_AXIS));
-  // console.log('lower stretch factor: ');
-  // console.log(lowerStretchFactors);
-
-  // return lowerStretchFactors;
-
-  const axisMinValue = config.axis.x.domain.lowerLimit;
-  const dataRangeMinValue = config.axis.x.dataRange.min < axisMinValue ? conf.axis.x.dataRange.min : axisMinValue;
-  const axisMidPoint = getMidPoint(config, constants.X_AXIS);
-  const lowerStretchFactor = Math.abs((axisMidPoint - dataRangeMinValue) / (axisMidPoint - axisMinValue));
-  
-  return lowerStretchFactor > 1 ? lowerStretchFactor : 1;
-};
-
-/**
- * Calculates the lower part of the outlier based on data points.
- * If the content has any data points that are outside the lower and upper bounds set
- * in the vertical axis then we adjust the axis bounds to support that outlier value.
- *
- * @private
- * @param {object} config - config object derived from input JSON
- * @returns {Array} List of lower bound values for each of the vertical axis
- */
-const getLowerOutlierStretchFactorList = (config) => {
-  const lowerStretchFactors = [];
-  const getMinValue = (conf, yAxis, axisMinValue) => {
-    const dataRangeMinValue = conf.axis[yAxis].dataRange.min;
-    return dataRangeMinValue < axisMinValue
-      ? dataRangeMinValue
-      : axisMinValue;
-  };
-  const getLowerStretchFactor = (yAxis) => {
-    const axisMinValue = config.axis[yAxis].domain.lowerLimit;
-    const axisMidPoint = getMidPoint(config, yAxis);
-    const lowerStretchFactor = Math.abs(
-      (axisMidPoint - getMinValue(config, yAxis, axisMinValue))
-                / (axisMidPoint - axisMinValue),
-    );
-    return lowerStretchFactor > 1 ? lowerStretchFactor : 1;
-  };
-  lowerStretchFactors.push(getLowerStretchFactor(constants.Y_AXIS));
-  if (hasY2Axis(config.axis)) {
-    lowerStretchFactors.push(getLowerStretchFactor(constants.Y2_AXIS));
-  }
-  return lowerStretchFactors;
-};
-
-/**
- * Calculates the lower part of the outlier based on data points.
- * If the content has any data points that are outside the lower and upper bounds set
- * in the vertical axis then we adjust the axis bounds to support that outlier value.
- *
- * @private
- * @param {object} config - config object derived from input JSON
- * @returns {Array} List of lower bound values for each of the vertical axis
- */
-const getLowerStretchFactorYAxis = (config, yAxis) => {
-  const axisMinValue = config.axis[yAxis].domain.lowerLimit;
-  const dataRangeMinValue = config.axis[yAxis].dataRange.min < axisMinValue ? config.axis[yAxis].dataRange.min : axisMinValue;
-  const axisMidPoint = getMidPoint(config, yAxis);
-  const lowerStretchFactor = Math.abs((axisMidPoint - dataRangeMinValue) / (axisMidPoint - axisMinValue));
-  return lowerStretchFactor > 1 ? lowerStretchFactor : 1;
-};
-
-/**
- * Updates the x axis domain values.
+ * Sets the x axis domain values.
  *
  * @private
  * @param {object} config - config object derived from input JSON
  */
-const setXAxisDomain = (config) => {
+ const setXAxisDomain = (config) => {
   config.axis.x.domain = getXAxisDomain(
     config.axis.x.type,
     config.axis.x.lowerLimit,
     config.axis.x.upperLimit,
   );
-};
-/**
- * Calculates the upper part of the outlier based on data points.
- * If the content has any data points that are outside the lower and upper bounds set
- * in the vertical axis then we adjust the axis bounds to support that outlier value.
- *
- * @private
- * @param {object} config - config object derived from input JSON
- * @returns {Array} List of upper bound values for each of the vertical axis
- */
-const getUpperOutlierStretchFactorList = (config) => {
-  const upperStretchFactors = [];
-
-  // const getMaxValue = (conf, yAxis, axisMaxValue) => {
-  //   const dataRangeMaxValue = conf.axis[yAxis].dataRange.max;
-  //   return dataRangeMaxValue > axisMaxValue
-  //     ? dataRangeMaxValue
-  //     : axisMaxValue;
-  // };
-
-  const getUpperStretchFactor = (yAxis) => {
-
-    const axisMaxValue = config.axis[yAxis].domain.upperLimit;
-
-    const dataRangeMaxValue = config.axis[yAxis].dataRange.max > axisMaxValue ? config.axis[yAxis].dataRange.max: axisMaxValue;
-
-    const axisMidPoint = getMidPoint(config, yAxis);
-    const upperStretchFactor = Math.abs(
-      (dataRangeMaxValue - axisMidPoint)
-                / (axisMaxValue - axisMidPoint),
-    );
-    return upperStretchFactor > 1 ? upperStretchFactor : 1;
-  };
-
-  upperStretchFactors.push(getUpperStretchFactor(constants.Y_AXIS));
-  if (hasY2Axis(config.axis)) {
-    upperStretchFactors.push(getUpperStretchFactor(constants.Y2_AXIS));
-  }
-  return upperStretchFactors;
 };
 
 /**
@@ -1455,51 +1325,32 @@ const getUpperOutlierStretchFactorList = (config) => {
  * @returns {number} upper bound value for of the input vertical axis
  */
 
-const getUpperStretchFactorYAxis = (config, yAxis) => {
-
-  const axisMaxValue = config.axis[yAxis].domain.upperLimit;
-  const dataRangeMaxValue = config.axis[yAxis].dataRange.max > axisMaxValue ? config.axis[yAxis].dataRange.max: axisMaxValue;
-  const axisMidPoint = getMidPoint(config, yAxis);
+ const getUpperOutlierStretchFactor = (config, axis) => {
+  const axisMaxValue = config.axis[axis].domain.upperLimit;
+  const dataRangeMaxValue = config.axis[axis].dataRange.max > axisMaxValue ? config.axis[axis].dataRange.max: axisMaxValue;
+  const axisMidPoint = getMidPoint(config, axis);
   const upperStretchFactor = Math.abs((dataRangeMaxValue - axisMidPoint) / (axisMaxValue - axisMidPoint));
   return upperStretchFactor > 1 ? upperStretchFactor : 1;
 };
 
 /**
- * Calculates the upper part of the outlier based on data points.
+ * Calculates the lower part of the outlier based on data points.
  * If the content has any data points that are outside the lower and upper bounds set
  * in the vertical axis then we adjust the axis bounds to support that outlier value.
  *
  * @private
  * @param {object} config - config object derived from input JSON
- * @returns {number} List of upper bound values for each of the vertical axis
+ * @returns {Array} List of lower bound values for each of the vertical axis
  */
-const getUpperOutlierStretchFactorXAxis = (config) => {
-  // const upperStretchFactors = [];
-  // const getMaxValue = (conf, xAxis, axisMaxValue) => {
-  //   const dataRangeMaxValue = conf.axis.x.dataRange.max;
-  //   console.log(dataRangeMaxValue);
-  //   return dataRangeMaxValue > axisMaxValue
-  //     ? dataRangeMaxValue
-  //     : axisMaxValue;
-  // };
-  // const getUpperStretchFactor = (xAxis) => {
-  //   const axisMaxValue = config.axis[xAxis].domain.upperLimit;
-  //   const axisMidPoint = getMidPoint(config, xAxis);
-  //   const upperStretchFactor = Math.abs(
-  //     (getMaxValue(config, xAxis, axisMaxValue) - axisMidPoint)
-  //               / (axisMaxValue - axisMidPoint),
-  //   );
-  //   return upperStretchFactor > 1 ? upperStretchFactor : 1;
-  // };
-  // upperStretchFactors.push(getUpperStretchFactor(constants.X_AXIS));
+// eslint-disable-next-line no-unused-vars
+const getLowerOutlierStretchFactor = (config, axis) => {
 
-  // return upperStretchFactors;
-
-  const axisMaxValue = config.axis.x.domain.upperLimit;
-  const dataRangeMaxValue = config.axis.x.dataRange.max > axisMaxValue ? config.axis.x.dataRange.max: axisMaxValue;
-  const axisMidPoint = getMidPoint(config, constants.X_AXIS);
-  const upperStretchFactor = Math.abs((dataRangeMaxValue - axisMidPoint) / (axisMaxValue - axisMidPoint));
-  return upperStretchFactor > 1 ? upperStretchFactor : 1;
+  const axisMinValue = config.axis[axis].domain.lowerLimit;
+  const dataRangeMinValue = config.axis[axis].dataRange.min < axisMinValue ? config.axis[axis].dataRange.min : axisMinValue;
+  const axisMidPoint = getMidPoint(config, axis);
+  const lowerStretchFactor = Math.abs((axisMidPoint - dataRangeMinValue) / (axisMidPoint - axisMinValue));
+  
+  return lowerStretchFactor > 1 ? lowerStretchFactor : 1;
 };
 
 /**
@@ -1511,14 +1362,12 @@ const getUpperOutlierStretchFactorXAxis = (config) => {
 * @param {object} config - config object derived from input JSON
 * @returns {object} stretch factor determines the new upper and lower limit.
 */
-//
 const determineOutlierStretchFactorXAxis = (config) => {
 
-  const sortOutlier = (firstValue, secondValue) => secondValue - firstValue;
   let stretchFactors = {};
 
-  stretchFactors.upperLimit = getUpperOutlierStretchFactorXAxis(config);
-  stretchFactors.lowerLimit = getLowerOutlierStretchFactorXAxis(config);
+  stretchFactors.upperLimit = getUpperOutlierStretchFactor(config, constants.X_AXIS);
+  stretchFactors.lowerLimit = getLowerOutlierStretchFactor(config, constants.X_AXIS);
 
   return stretchFactors;
 
@@ -1533,50 +1382,22 @@ const determineOutlierStretchFactorXAxis = (config) => {
  * @param {object} config - config object derived from input JSON
  * @returns {object} stretch factor determines the new upper and lower limit.
  */
-const determineOutlierStretchFactor = (config) => {
-  const sortOutlier = (firstValue, secondValue) => secondValue - firstValue;
+const determineOutlierStretchFactorYAxes = (config) => {
   let stretchFactors = {};
 
-  const upperStretchFactors = [];
-  const lowerStretchFactors = [];
-
-  stretchFactors.upperLimit = getUpperStretchFactorYAxis(config, constants.Y_AXIS);
-  stretchFactors.lowerLimit = getLowerStretchFactorYAxis(config, constants.Y_AXIS);
-
-  upperStretchFactors.push(stretchFactors.upperLimit);
-  lowerStretchFactors.push(stretchFactors.lowerLimit);
-
-
+  stretchFactors.upperLimit = getUpperOutlierStretchFactor(config, constants.Y_AXIS);
+  stretchFactors.lowerLimit = getLowerOutlierStretchFactor(config, constants.Y_AXIS);
 
   if (hasY2Axis(config.axis)) {
-    upperStretchFactors.push(getUpperStretchFactorYAxis(config, constants.Y2_AXIS));
-    lowerStretchFactors.push(getLowerStretchFactorYAxis(config, constants.Y2_AXIS));
 
-    let upperLimitY2 = getUpperStretchFactorYAxis(config, constants.Y2_AXIS);
-    let lowerLimitY2 = getLowerStretchFactorYAxis(config, constants.Y2_AXIS);
+    let upperLimitY2 = getUpperOutlierStretchFactor(config, constants.Y2_AXIS);
+    let lowerLimitY2 = getLowerOutlierStretchFactor(config, constants.Y2_AXIS);
 
     stretchFactors.upperLimit = upperLimitY2 > stretchFactors.upperLimit ? upperLimitY2 : stretchFactors.upperLimit;
     stretchFactors.lowerLimit = lowerLimitY2 > stretchFactors.lowerLimit ? lowerLimitY2 : stretchFactors.lowerLimit;
   }
-
-  // console.log(lowerStretchFactors);
-
-
-  // stretchFactors.upperLimit = upperStretchFactors.sort(sortOutlier)[0];
-  // stretchFactors.lowerLimit = lowerStretchFactors.sort(sortOutlier)[0];
-
-  // console.log(stretchFactors);
   
   return stretchFactors;
-
-  // return {
-  //   upperLimit: getUpperOutlierStretchFactorList(config).sort(
-  //     sortOutlier,
-  //   )[0],
-  //   lowerLimit: getLowerOutlierStretchFactorList(config).sort(
-  //     sortOutlier,
-  //   )[0],
-  // };
 };
 
 /**
@@ -1790,12 +1611,22 @@ const isValidAxisType = (x, xAxisType) => ((utils.isDate(x) || utils.isDateInsta
  * @enum {Function}
  */
 export {
-  prepareXAxis,
-  prepareHorizontalAxis,
-  prepareYAxis,
-  prepareY2Axis,
+  buildAxisLabel,
+  calculateAxesSize,
+  calculateAxesLabelSize,
+  calculateVerticalPadding,
+  createAxes,
+  createXAxisInfoRow,
+  createAxisReferenceLine,
+  determineOutlierStretchFactorXAxis,
+  determineOutlierStretchFactorYAxes,
+  formatLabel,
+  generateYAxesTickValues,
+  getAverageTicksCount,
+  getAxesDataRange,
+  getAxisInfoRowYPosition,
   getAxisTickFormat,
-  getRotationForAxis,
+  getAxesScale,
   getXAxisLabelXPosition,
   getXAxisLabelYPosition,
   getYAxisLabelXPosition,
@@ -1805,6 +1636,8 @@ export {
   getY2AxisLabelShapeXPosition,
   getYAxisLabelShapeYPosition,
   getY2AxisLabelShapeYPosition,
+  getRotationForAxis,
+  getTicksCountFromRange,
   getXAxisXPosition,
   getXAxisYPosition,
   getYAxisXPosition,
@@ -1819,28 +1652,16 @@ export {
   getAxisLabelWidth,
   getAxisLabelHeight,
   getYAxisWidth,
-  calculateAxesSize,
-  calculateAxesLabelSize,
-  determineOutlierStretchFactor,
-  determineOutlierStretchFactorXAxis,
-  buildAxisLabel,
-  getAxesScale,
-  createAxes,
-  createXAxisInfoRow,
-  createAxisReferenceLine,
-  getAxesDataRange,
-  processTickValues,
-  generateYAxesTickValues,
   hasY2Axis,
+  isXAxisOrientationTop,
+  isValidAxisType,
+  prepareHorizontalAxis,
+  processTickValues,
+  prepareXAxis,
+  prepareYAxis,
+  prepareY2Axis,
+  resetD3FontSize,
+  setXAxisDomain,
   translateAxes,
   translateAxisReferenceLine,
-  isValidAxisType,
-  resetD3FontSize,
-  calculateVerticalPadding,
-  isXAxisOrientationTop,
-  getAxisInfoRowYPosition,
-  setXAxisDomain,
-  getTicksCountFromRange,
-  getAverageTicksCount,
-  formatLabel,
 };

--- a/packages/carbon-graphs/src/js/helpers/axis.js
+++ b/packages/carbon-graphs/src/js/helpers/axis.js
@@ -1331,6 +1331,9 @@ const getUpperOutlierStretchFactor = (config, axis) => {
   const dataRangeMaxValue = config.axis[axis].dataRange.max > axisMaxValue ? config.axis[axis].dataRange.max : axisMaxValue;
   const axisMidPoint = getMidPoint(config, axis);
   const upperStretchFactor = Math.abs((dataRangeMaxValue - axisMidPoint) / (axisMaxValue - axisMidPoint));
+  
+  // console.log(upperStretchFactor);
+
   return upperStretchFactor > 1 ? upperStretchFactor : 1;
 };
 
@@ -1346,8 +1349,8 @@ const getUpperOutlierStretchFactor = (config, axis) => {
  */
 const getLowerOutlierStretchFactor = (config, axis) => {
   const axisMinValue = config.axis[axis].domain.lowerLimit;
-  const dataRangeMinValue = config.axis[axis].dataRange.min < axisMinValue ? config.axis[axis].dataRange.min : axisMinValue;
   const axisMidPoint = getMidPoint(config, axis);
+  const dataRangeMinValue = config.axis[axis].dataRange.min < axisMinValue ? config.axis[axis].dataRange.min : axisMinValue;
   const lowerStretchFactor = Math.abs((axisMidPoint - dataRangeMinValue) / (axisMidPoint - axisMinValue));
 
   return lowerStretchFactor > 1 ? lowerStretchFactor : 1;

--- a/packages/carbon-graphs/tests/unit/controls/Graph/GraphAxes-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Graph/GraphAxes-spec.js
@@ -1231,7 +1231,6 @@ describe('Graph - Axes', () => {
       for (let i = 1; i < allYAxisElements[0].childNodes.length; i += 1) {
         yTicks.push(parseInt(allYAxisElements[0].childNodes[i].querySelector('text').textContent, 10));
       }
-      console.log(yTicks);
     });
     describe('when space is passed as label', () => {
       beforeEach(() => {

--- a/packages/carbon-graphs/tests/unit/controls/Graph/GraphAxes-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Graph/GraphAxes-spec.js
@@ -1231,6 +1231,7 @@ describe('Graph - Axes', () => {
       for (let i = 1; i < allYAxisElements[0].childNodes.length; i += 1) {
         yTicks.push(parseInt(allYAxisElements[0].childNodes[i].querySelector('text').textContent, 10));
       }
+      console.log(yTicks);
     });
     describe('when space is passed as label', () => {
       beforeEach(() => {

--- a/packages/carbon-graphs/tests/unit/controls/Line/LineLoad-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Line/LineLoad-spec.js
@@ -138,8 +138,6 @@ fdescribe('Line - Load', () => {
   describe('draws the graph', () => {
     let input = null;
     beforeEach(() => {
-      // input = getInput(valuesDefault, false, false);
-      // graphDefault.loadContent(new Line(input));
     });
     afterEach(() => {
       if (typeof graphDefault.destroy === 'function') {

--- a/packages/carbon-graphs/tests/unit/controls/Line/LineLoad-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Line/LineLoad-spec.js
@@ -28,7 +28,7 @@ import {
   LINE_DASHED,
 } from '../../../../src/js/core/Shape/shapeDefinitions';
 
-describe('Line - Load', () => {
+fdescribe('Line - Load', () => {
   let graphDefault = null;
   let lineGraphContainer;
   beforeEach(() => {
@@ -43,6 +43,9 @@ describe('Line - Load', () => {
   });
   afterEach(() => {
     document.body.innerHTML = '';
+    if (typeof graphDefault.destroy === 'function') {
+      graphDefault.destroy();
+    }
   });
   it('returns the graph instance', () => {
     const loadedLine = new Line(getInput(valuesDefault, false, false));
@@ -135,10 +138,18 @@ describe('Line - Load', () => {
   describe('draws the graph', () => {
     let input = null;
     beforeEach(() => {
-      input = getInput(valuesDefault, false, false);
-      graphDefault.loadContent(new Line(input));
+      // input = getInput(valuesDefault, false, false);
+      // graphDefault.loadContent(new Line(input));
+    });
+    afterEach(() => {
+      if (typeof graphDefault.destroy === 'function') {
+        graphDefault.destroy();
+      }
     });
     it('adds content container for each line', () => {
+      input = getInput(valuesDefault, false, false);
+      graphDefault.loadContent(new Line(input));
+
       const lineContentContainer = fetchElementByClass(
         lineGraphContainer,
         styles.lineGraphContent,
@@ -150,6 +161,9 @@ describe('Line - Load', () => {
       );
     });
     it('adds container for each data points sets for each line', () => {
+      input = getInput(valuesDefault, false, false);
+      graphDefault.loadContent(new Line(input));
+
       const secInput = utils.deepClone(input);
       secInput.key = 'uid_2';
       graphDefault.loadContent(new Line(secInput));
@@ -159,6 +173,9 @@ describe('Line - Load', () => {
       expect(graphContent.length).toBe(2);
     });
     it('adds legend for each data points sets for each line', () => {
+      input = getInput(valuesDefault, false, false);
+      graphDefault.loadContent(new Line(input));
+
       const secInput = utils.deepClone(input);
       secInput.key = 'uid_2';
       graphDefault.loadContent(new Line(secInput));
@@ -168,7 +185,6 @@ describe('Line - Load', () => {
       expect(legendItems.length).toBe(2);
     });
     it('disables legend when disabled flag is set', () => {
-      graphDefault.destroy();
       const graph = new Graph(getAxes(axisDefault));
       const data = utils.deepClone(valuesDefault);
       input = getInput(data);
@@ -180,7 +196,6 @@ describe('Line - Load', () => {
       expect(legendItem.getAttribute('aria-disabled')).toBe('true');
     });
     it('disabled legend item is not tab-able', () => {
-      graphDefault.destroy();
       const graph = new Graph(getAxes(axisDefault));
       const data = utils.deepClone(valuesDefault);
       input = getInput(data);
@@ -192,6 +207,9 @@ describe('Line - Load', () => {
       expect(legendItem.getAttribute('tabindex')).toBe('-1');
     });
     it('add line group for line', () => {
+      input = getInput(valuesDefault, false, false);
+      graphDefault.loadContent(new Line(input));
+
       const lineContentContainer = fetchElementByClass(
         lineGraphContainer,
         styles.lineGraphContent,
@@ -205,6 +223,9 @@ describe('Line - Load', () => {
       expect(lineGroup.getAttribute('transform')).not.toBeNull();
     });
     it('adds line path as an SVG', () => {
+      input = getInput(valuesDefault, false, false);
+      graphDefault.loadContent(new Line(input));
+
       const lineContentContainer = fetchElementByClass(
         lineGraphContainer,
         styles.lineGraphContent,
@@ -219,6 +240,9 @@ describe('Line - Load', () => {
       ).toBeTruthy();
     });
     it('adds line with correct color with default stroke-dasharray to 0', () => {
+      input = getInput(valuesDefault, false, false);
+      graphDefault.loadContent(new Line(input));
+
       const lineElement = fetchElementByClass(
         lineGraphContainer,
         styles.line,
@@ -229,6 +253,9 @@ describe('Line - Load', () => {
       ).toBe(`stroke: ${COLORS.GREEN}; stroke-dasharray: 0;`);
     });
     it('adds line with correct unique key', () => {
+      input = getInput(valuesDefault, false, false);
+      graphDefault.loadContent(new Line(input));
+
       const lineElement = fetchElementByClass(
         lineGraphContainer,
         styles.line,
@@ -240,7 +267,6 @@ describe('Line - Load', () => {
       ).toBe(input.key);
     });
     it('does not render data point if data point is null', () => {
-      graphDefault.destroy();
       const graph = new Graph(getAxes(axisDefault));
       const data = utils.deepClone(valuesDefault);
       data[0].y = null;
@@ -258,7 +284,6 @@ describe('Line - Load', () => {
       expect(selectedPoint.getAttribute('aria-hidden')).toContain('true');
     });
     it('does not render data point if data point is undefiend', () => {
-      graphDefault.destroy();
       const graph = new Graph(getAxes(axisDefault));
       const data = utils.deepClone(valuesDefault);
       data[0].y = undefined;
@@ -276,7 +301,6 @@ describe('Line - Load', () => {
       expect(selectedPoint.getAttribute('aria-hidden')).toContain('true');
     });
     it('does not render points if shapes needs to be hidden', () => {
-      graphDefault.destroy();
       const hiddenShapeInput = getAxes(axisDefault);
       hiddenShapeInput.showShapes = false;
       const hiddenShapeGraph = new Graph(hiddenShapeInput);
@@ -289,34 +313,85 @@ describe('Line - Load', () => {
         ),
       ).toBeNull();
     });
+    it('does not update x axis range if allow calibration is disabled', () => {
+      const disableCalibrationInput = getAxes(axisDefault);
+      disableCalibrationInput.axis.x.allowCalibration = false;
+      disableCalibrationInput.axis.x.lowerLimit = 50;
+      const disableCalibrationGraph = new Graph(disableCalibrationInput);
+      input = getInput(valuesDefault, false, false);
+      disableCalibrationGraph.loadContent(new Line(input));
+
+      expect(disableCalibrationGraph.config.axis.x.domain.upperLimit)
+        .toEqual(disableCalibrationInput.axis.x.upperLimit);
+      expect(disableCalibrationGraph.config.axis.x.domain.lowerLimit)
+        .toEqual(disableCalibrationInput.axis.x.lowerLimit);
+    });
+    it('does not update x axis range by default if allowCalibration is undefined', () => {
+      const disableCalibrationInput = getAxes(axisDefault);
+      disableCalibrationInput.axis.x.allowCalibration = undefined;
+      disableCalibrationInput.axis.x.lowerLimit = 50;
+      const disableCalibrationGraph = new Graph(disableCalibrationInput);
+      input = getInput(valuesDefault, false, false);
+      disableCalibrationGraph.loadContent(new Line(input));
+
+      expect(disableCalibrationGraph.config.axis.x.domain.upperLimit)
+        .toEqual(disableCalibrationInput.axis.x.upperLimit);
+      expect(disableCalibrationGraph.config.axis.x.domain.lowerLimit)
+        .toEqual(disableCalibrationInput.axis.x.lowerLimit);
+    });
+    it('does not x axis range if allowCalibration is true and datapoints are within limits', () => {
+      const disableCalibrationInput = getAxes(axisDefault);
+      disableCalibrationInput.axis.x.allowCalibration = true;
+      disableCalibrationInput.axis.x.lowerLimit = 20;
+      disableCalibrationInput.axis.x.upperLimit = 70;
+
+      const disableCalibrationGraph = new Graph(disableCalibrationInput);
+      input = getInput(valuesDefault, false, false);
+      disableCalibrationGraph.loadContent(new Line(input));
+
+      expect(disableCalibrationGraph.config.axis.x.domain.lowerLimit).toEqual(20);
+      expect(disableCalibrationGraph.config.axis.x.domain.upperLimit).toEqual(70);
+    });
+    it('updates x axis range if allowCalibration is true and datapoints exceed or are equal to limits', () => {
+      const disableCalibrationInput = getAxes(axisDefault);
+      disableCalibrationInput.axis.x.allowCalibration = true;
+      disableCalibrationInput.axis.x.lowerLimit = 30;
+      disableCalibrationInput.axis.x.upperLimit = 45;
+
+      const disableCalibrationGraph = new Graph(disableCalibrationInput);
+      input = getInput(valuesDefault, false, false);
+      disableCalibrationGraph.loadContent(new Line(input));
+
+      expect(disableCalibrationGraph.config.axis.x.domain.lowerLimit).toEqual(24);
+      expect(disableCalibrationGraph.config.axis.x.domain.upperLimit).toEqual(46);
+    });
     it('does not update y axis range if allow calibration is disabled', () => {
-      graphDefault.destroy();
       const disableCalibrationInput = getAxes(axisDefault);
       disableCalibrationInput.allowCalibration = false;
       const disableCalibrationGraph = new Graph(disableCalibrationInput);
       input = getInput(valuesDefault, false, false);
       disableCalibrationGraph.loadContent(new Line(input));
-      expect(disableCalibrationInput.axis.y.upperLimit).toEqual(
-        disableCalibrationGraph.config.axis.y.domain.upperLimit,
-      );
-      expect(disableCalibrationInput.axis.y.lowerLimit).toEqual(
-        disableCalibrationGraph.config.axis.y.domain.lowerLimit,
-      );
+
+      expect(disableCalibrationGraph.config.axis.y.domain.upperLimit)
+        .toEqual(disableCalibrationInput.axis.y.upperLimit);
+      expect(disableCalibrationGraph.config.axis.y.domain.lowerLimit)
+        .toEqual(disableCalibrationInput.axis.y.lowerLimit);
     });
     it('update y axis range by default', () => {
-      graphDefault.destroy();
       const disableCalibrationInput = getAxes(axisDefault);
       const disableCalibrationGraph = new Graph(disableCalibrationInput);
       input = getInput(valuesDefault, false, false);
       disableCalibrationGraph.loadContent(new Line(input));
-      expect(disableCalibrationInput.axis.y.upperLimit).not.toEqual(
-        disableCalibrationGraph.config.axis.y.domain.upperLimit,
-      );
-      expect(disableCalibrationInput.axis.y.lowerLimit).not.toEqual(
-        disableCalibrationGraph.config.axis.y.domain.lowerLimit,
-      );
+
+      expect(disableCalibrationGraph.config.axis.y.domain.upperLimit)
+        .not.toEqual(disableCalibrationInput.axis.y.upperLimit);
+      expect(disableCalibrationGraph.config.axis.y.domain.lowerLimit)
+        .not.toEqual(disableCalibrationInput.axis.y.lowerLimit);
     });
     it('add points group for data points', () => {
+      input = getInput(valuesDefault, false, false);
+      graphDefault.loadContent(new Line(input));
+
       const pointsGroup = fetchElementByClass(
         lineGraphContainer,
         styles.currentPointsGroup,
@@ -326,6 +401,9 @@ describe('Line - Load', () => {
       expect(pointsGroup.getAttribute('transform')).not.toBeNull();
     });
     it('adds points for each data point', () => {
+      input = getInput(valuesDefault, false, false);
+      graphDefault.loadContent(new Line(input));
+
       const pointsGroup = fetchElementByClass(
         lineGraphContainer,
         styles.currentPointsGroup,
@@ -334,6 +412,9 @@ describe('Line - Load', () => {
       expect(points.length).toBe(valuesDefault.length);
     });
     it('points have correct color', () => {
+      input = getInput(valuesDefault, false, false);
+      graphDefault.loadContent(new Line(input));
+
       const pointsGroup = fetchElementByClass(
         lineGraphContainer,
         styles.currentPointsGroup,
@@ -344,6 +425,9 @@ describe('Line - Load', () => {
       );
     });
     it('points have correct shape', () => {
+      input = getInput(valuesDefault, false, false);
+      graphDefault.loadContent(new Line(input));
+
       const pointsGroup = fetchElementByClass(
         lineGraphContainer,
         styles.currentPointsGroup,
@@ -354,6 +438,9 @@ describe('Line - Load', () => {
       ).toBe(SHAPES.RHOMBUS.path.d);
     });
     it('points have correct unique key assigned', () => {
+      input = getInput(valuesDefault, false, false);
+      graphDefault.loadContent(new Line(input));
+
       const pointsGroup = fetchElementByClass(
         lineGraphContainer,
         styles.currentPointsGroup,
@@ -362,6 +449,9 @@ describe('Line - Load', () => {
       expect(points.getAttribute('aria-describedby')).toBe(input.key);
     });
     it('adds a selected data point for each point', () => {
+      input = getInput(valuesDefault, false, false);
+      graphDefault.loadContent(new Line(input));
+
       const pointsGroup = fetchElementByClass(
         lineGraphContainer,
         styles.currentPointsGroup,
@@ -372,6 +462,9 @@ describe('Line - Load', () => {
       expect(selectedPoints.length).toBe(valuesDefault.length);
     });
     it('selected data point is hidden by default', () => {
+      input = getInput(valuesDefault, false, false);
+      graphDefault.loadContent(new Line(input));
+
       const selectedPoints = fetchElementByClass(
         lineGraphContainer,
         styles.dataPointSelection,
@@ -379,6 +472,9 @@ describe('Line - Load', () => {
       expect(selectedPoints.getAttribute('aria-hidden')).toBe('true');
     });
     it('selected data point has circle as shape', () => {
+      input = getInput(valuesDefault, false, false);
+      graphDefault.loadContent(new Line(input));
+
       const selectedPoints = fetchElementByClass(
         lineGraphContainer,
         styles.dataPointSelection,
@@ -389,6 +485,9 @@ describe('Line - Load', () => {
       );
     });
     it('selected data point has correct unique key assigned', () => {
+      input = getInput(valuesDefault, false, false);
+      graphDefault.loadContent(new Line(input));
+
       const selectedPoints = fetchElementByClass(
         lineGraphContainer,
         styles.dataPointSelection,
@@ -398,7 +497,6 @@ describe('Line - Load', () => {
       );
     });
     it('does not render points if shapes are hidden per data set', () => {
-      graphDefault.destroy();
       const hiddenShapeInput = getAxes(axisDefault);
       hiddenShapeInput.showShapes = true;
       const hiddenShapeGraph = new Graph(hiddenShapeInput);
@@ -414,7 +512,6 @@ describe('Line - Load', () => {
     });
     describe('adds line with stroke-dasharray as provided by consumer with', () => {
       it('comma seperated values', () => {
-        graphDefault.destroy();
         graphDefault = new Graph(getAxes(axisDefault));
         input = getInput(valuesDefault, false, false);
         input.style = {
@@ -433,7 +530,6 @@ describe('Line - Load', () => {
         ).toBe(`stroke: ${COLORS.GREEN}; stroke-dasharray: 2,2;`);
       });
       it('space seperated values', () => {
-        graphDefault.destroy();
         graphDefault = new Graph(getAxes(axisDefault));
         input = getInput(valuesDefault, false, false);
         input.style = {
@@ -452,7 +548,6 @@ describe('Line - Load', () => {
         ).toBe(`stroke: ${COLORS.GREEN}; stroke-dasharray: 2 2;`);
       });
       it('just a single value', () => {
-        graphDefault.destroy();
         graphDefault = new Graph(getAxes(axisDefault));
         input = getInput(valuesDefault, false, false);
         input.style = {
@@ -474,7 +569,6 @@ describe('Line - Load', () => {
     it('adds line with correct stroke-dasharray', () => {});
     describe('when clicked on a data point', () => {
       it('does not do anything if no onClick callback is provided', (done) => {
-        graphDefault.destroy();
         graphDefault = new Graph(getAxes(axisDefault));
         input = getInput(valuesDefault, false, false);
         input.onClick = null;
@@ -489,7 +583,6 @@ describe('Line - Load', () => {
         });
       });
       it('hides data point selection when parameter callback is called', (done) => {
-        graphDefault.destroy();
         graphDefault = new Graph(getAxes(axisDefault));
         input = getInput(valuesDefault, false, false);
         input.onClick = (clearSelectionCallback) => {
@@ -513,7 +606,6 @@ describe('Line - Load', () => {
       });
       it('calls onClick callback', (done) => {
         const dataPointClickHandlerSpy = sinon.spy();
-        graphDefault.destroy();
         graphDefault = new Graph(getAxes(axisDefault));
         input = getInput(valuesDefault, false, false);
         input.onClick = dataPointClickHandlerSpy;
@@ -529,7 +621,6 @@ describe('Line - Load', () => {
       });
       it('calls onClick callback with parameters', (done) => {
         let args = {};
-        graphDefault.destroy();
         graphDefault = new Graph(getAxes(axisDefault));
         input = getInput(valuesDefault, false, false);
         input.onClick = (cb, key, index, val, target) => {
@@ -558,6 +649,9 @@ describe('Line - Load', () => {
         });
       });
       it('highlights the data point', (done) => {
+        input = getInput(valuesDefault, false, false);
+        graphDefault.loadContent(new Line(input));
+
         const selectionPoint = fetchElementByClass(
           lineGraphContainer,
           styles.dataPointSelection,
@@ -574,6 +668,9 @@ describe('Line - Load', () => {
         });
       });
       it('removes highlight when data point is clicked again', (done) => {
+        input = getInput(valuesDefault, false, false);
+        graphDefault.loadContent(new Line(input));
+
         const selectionPoint = fetchElementByClass(
           lineGraphContainer,
           styles.dataPointSelection,
@@ -594,6 +691,9 @@ describe('Line - Load', () => {
     });
     describe("when clicked on a data point's near surrounding area", () => {
       it('highlights the data point', (done) => {
+        input = getInput(valuesDefault, false, false);
+        graphDefault.loadContent(new Line(input));
+
         const selectionPoint = fetchElementByClass(
           lineGraphContainer,
           styles.dataPointSelection,
@@ -607,7 +707,6 @@ describe('Line - Load', () => {
       });
       it('calls onClick callback with parameters', (done) => {
         let args = {};
-        graphDefault.destroy();
         graphDefault = new Graph(getAxes(axisDefault));
         input = getInput(valuesDefault, false, false);
         input.onClick = (cb, key, index, val, target) => {
@@ -636,6 +735,9 @@ describe('Line - Load', () => {
         });
       });
       it('removes highlight when clicked again', (done) => {
+        input = getInput(valuesDefault, false, false);
+        graphDefault.loadContent(new Line(input));
+
         const selectionPoint = fetchElementByClass(
           lineGraphContainer,
           styles.dataPointSelection,
@@ -652,7 +754,6 @@ describe('Line - Load', () => {
     });
     describe('When interpolation type is provided', () => {
       it('Displays graph properly', () => {
-        graphDefault.destroy();
         const graph = new Graph(getAxes(axisDefault));
         input = getInput(valuesDefault);
         input.type = LINE_TYPE.SPLINE;
@@ -689,7 +790,6 @@ describe('Line - Load', () => {
       ];
       describe('In Y Axis', () => {
         it('Displays graph properly', () => {
-          graphDefault.destroy();
           const graph = new Graph(getAxes(axis));
           input = getInput(values, true, true, false);
           input.values = values;
@@ -707,7 +807,6 @@ describe('Line - Load', () => {
           expect(graph.config.axis.y.domain.upperLimit).toBe(209);
         });
         it('Displays graph properly without domain padding', () => {
-          graphDefault.destroy();
           const data = getAxes(axis);
           data.axis.y.padDomain = false;
           const graph = new Graph(data);
@@ -729,7 +828,6 @@ describe('Line - Load', () => {
       });
       describe('In Y2 Axis', () => {
         it('Displays graph properly', () => {
-          graphDefault.destroy();
           const graph = new Graph(getAxes(axis));
           input = getInput(values, true, true, true);
           graph.loadContent(new Line(input));
@@ -746,7 +844,6 @@ describe('Line - Load', () => {
           expect(graph.config.axis.y2.domain.upperLimit).toBe(209);
         });
         it('Displays graph properly without domain padding', () => {
-          graphDefault.destroy();
           const data = getAxes(axis);
           data.axis.y2.padDomain = false;
           const graph = new Graph(data);


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
This PR finishes implementation for the the `axis.x.allowCalibration` prop for a line graph.

Note: this feature is still a work in progress and will break if used for anything besides a line graph with a numerical x-axis. However, this is still a passive change since this feature needs to be explicitly toggled on. 

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-graphs-deployed-pr-45.herokuapp.com/ -->
https://terra-graphs-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
@cerner/carbon
