### PR TITLE
Add allowCalibration to the x-axis for a timeseries line graph (PR 1 of 2)

### DIFF
--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added
   * Added preliminary logic for new prop `config.axis.x.allowCalibration` to automatically update axis limits to allow padding.
   * Finished implementation for `config.axis.x.allowCalibration` for a line graph with a numerical x-axis.
+  * Finished implementation for `config.axis.x.allowCalibration` for a line graph with a timeseries x-axis.
 
 ## 2.21.0 - (February 15, 2022)
 

--- a/packages/carbon-graphs/src/js/controls/Graph/Graph.js
+++ b/packages/carbon-graphs/src/js/controls/Graph/Graph.js
@@ -120,6 +120,7 @@ const beforeInit = (control) => {
     console.warn('allowCalibration for x-axis is a new feature that is currently a work in progress and may have stability issues. Use it at your own risk.');
     getAxesDataRange({}, constants.X_AXIS, control.config);
   }
+  
   updateAxesDomain(control.config);
   updateXAxisDomain(control.config);
   createTooltipDiv();

--- a/packages/carbon-graphs/src/js/controls/Graph/Graph.js
+++ b/packages/carbon-graphs/src/js/controls/Graph/Graph.js
@@ -120,7 +120,7 @@ const beforeInit = (control) => {
     console.warn('allowCalibration for x-axis is a new feature that is currently a work in progress and may have stability issues. Use it at your own risk.');
     getAxesDataRange({}, constants.X_AXIS, control.config);
   }
-  
+
   updateAxesDomain(control.config);
   updateXAxisDomain(control.config);
   createTooltipDiv();

--- a/packages/carbon-graphs/src/js/controls/Graph/helpers/helpers.js
+++ b/packages/carbon-graphs/src/js/controls/Graph/helpers/helpers.js
@@ -501,8 +501,6 @@ const updateXAxisDomain = (config, input = {}) => {
     return config;
   }
 
-  // console.log(config.axis.x.domain);
-
   // if the x-axis type is timeseries then convert to epoc date so it is a number for calculations
   if (config.axis.x.type === AXIS_TYPE.TIME_SERIES) {
     config.axis.x.domain.upperLimit = utils.getEpocFromDateString(config.axis.x.domain.upperLimit);

--- a/packages/carbon-graphs/src/js/controls/Graph/helpers/helpers.js
+++ b/packages/carbon-graphs/src/js/controls/Graph/helpers/helpers.js
@@ -28,7 +28,7 @@ import {
   translateAxisReferenceLine,
   formatLabel,
 } from '../../../helpers/axis';
-import constants, { SHAPES } from '../../../helpers/constants';
+import constants, { AXIS_TYPE, SHAPES } from '../../../helpers/constants';
 import { createVGrid, translateVGrid } from '../../../helpers/datetimeBuckets';
 import {
   buildY2AxisLabelShapeContainer,
@@ -500,6 +500,18 @@ const updateXAxisDomain = (config, input = {}) => {
   if (utils.isEmpty(input) || !config.axis.x.allowCalibration) {
     return config;
   }
+  
+  // console.log(config.axis.x.domain);
+
+  // if the x-axis type is timeseries then convert to epoc date so it is a number for calculations
+  if(config.axis.x.type == AXIS_TYPE.TIME_SERIES){
+    config.axis.x.domain.upperLimit = utils.getEpocFromDateString(config.axis.x.domain.upperLimit);
+    config.axis.x.domain.lowerLimit = utils.getEpocFromDateString(config.axis.x.domain.lowerLimit);
+    // Note: config.axis.x.dataRange.max and min are already numbers.
+    // In the case of a timeseries x-axis, they are the epoc representation
+    // of a date. Which is why only config.axis.x.domain.upperLimit and lowerLimit
+    // are converted to epoc.
+  }
 
   config.axis.x.outlierStretchFactor = determineOutlierStretchFactorXAxis(config);
 
@@ -510,6 +522,7 @@ const updateXAxisDomain = (config, input = {}) => {
     upperLimit: midPoint + halfDomain * config.axis.x.outlierStretchFactor.upperLimit,
   };
 
+
   if (newDomain.upperLimit === config.axis.x.dataRange.max
      || newDomain.lowerLimit === config.axis.x.dataRange.min) {
     config.axisPadding.x = true;
@@ -518,7 +531,17 @@ const updateXAxisDomain = (config, input = {}) => {
   }
 
   config.axis.x.domain = padDomain(newDomain, config.axisPadding.x);
-
+  
+  // if the x-axis type is timeseries then convert the updated epoc date back to a string
+  if(config.axis.x.type == AXIS_TYPE.TIME_SERIES){
+    config.axis.x.domain.upperLimit = utils.getDateFromEpoc(config.axis.x.domain.upperLimit);
+    config.axis.x.domain.lowerLimit = utils.getDateFromEpoc(config.axis.x.domain.lowerLimit);
+    // Note: config.axis.x.domain.upperLimit and lowerLimit are converted back to a Date object
+    // because that is how it is used in the rest of the code. Outside of this method, 
+    // config.axis.x.dataRange.max and min are not utilized which is why converting them
+    // back to a date object is redundant.
+  }
+  
   return config;
 };
 /**

--- a/packages/carbon-graphs/src/js/controls/Graph/helpers/helpers.js
+++ b/packages/carbon-graphs/src/js/controls/Graph/helpers/helpers.js
@@ -500,11 +500,11 @@ const updateXAxisDomain = (config, input = {}) => {
   if (utils.isEmpty(input) || !config.axis.x.allowCalibration) {
     return config;
   }
-  
+
   // console.log(config.axis.x.domain);
 
   // if the x-axis type is timeseries then convert to epoc date so it is a number for calculations
-  if(config.axis.x.type == AXIS_TYPE.TIME_SERIES){
+  if (config.axis.x.type === AXIS_TYPE.TIME_SERIES) {
     config.axis.x.domain.upperLimit = utils.getEpocFromDateString(config.axis.x.domain.upperLimit);
     config.axis.x.domain.lowerLimit = utils.getEpocFromDateString(config.axis.x.domain.lowerLimit);
     // Note: config.axis.x.dataRange.max and min are already numbers.
@@ -522,7 +522,6 @@ const updateXAxisDomain = (config, input = {}) => {
     upperLimit: midPoint + halfDomain * config.axis.x.outlierStretchFactor.upperLimit,
   };
 
-
   if (newDomain.upperLimit === config.axis.x.dataRange.max
      || newDomain.lowerLimit === config.axis.x.dataRange.min) {
     config.axisPadding.x = true;
@@ -531,17 +530,17 @@ const updateXAxisDomain = (config, input = {}) => {
   }
 
   config.axis.x.domain = padDomain(newDomain, config.axisPadding.x);
-  
+
   // if the x-axis type is timeseries then convert the updated epoc date back to a string
-  if(config.axis.x.type == AXIS_TYPE.TIME_SERIES){
+  if (config.axis.x.type === AXIS_TYPE.TIME_SERIES) {
     config.axis.x.domain.upperLimit = utils.getDateFromEpoc(config.axis.x.domain.upperLimit);
     config.axis.x.domain.lowerLimit = utils.getDateFromEpoc(config.axis.x.domain.lowerLimit);
     // Note: config.axis.x.domain.upperLimit and lowerLimit are converted back to a Date object
-    // because that is how it is used in the rest of the code. Outside of this method, 
+    // because that is how it is used in the rest of the code. Outside of this method,
     // config.axis.x.dataRange.max and min are not utilized which is why converting them
     // back to a date object is redundant.
   }
-  
+
   return config;
 };
 /**

--- a/packages/carbon-graphs/src/js/controls/Line/Line.js
+++ b/packages/carbon-graphs/src/js/controls/Line/Line.js
@@ -73,7 +73,14 @@ const calculateValuesRangeYAxis = (values) => {
  * @returns {object} - Contains min and max values for the data points for Y and Y2 axis
  */
 const calculateValuesRangeXAxis = (values) => {
-  const xAxisValuesList = values.filter((i) => i.x !== null && i.x !== undefined).map((i) => i.x);
+  const xAxisValuesList = values.filter((i) => i.x !== null && i.x !== undefined).map((i) => {
+    // if the x-axis is a timeseries, then convert it to an epoc int
+    // for easier calculations
+    if(typeof i.x === "string"||i.x instanceof Date){
+      return utils.getEpocFromDateString(i.x);
+    }
+    return i.x;
+  });
   return {
     min: Math.min(...xAxisValuesList),
     max: Math.max(...xAxisValuesList),

--- a/packages/carbon-graphs/src/js/controls/Line/Line.js
+++ b/packages/carbon-graphs/src/js/controls/Line/Line.js
@@ -76,7 +76,7 @@ const calculateValuesRangeXAxis = (values) => {
   const xAxisValuesList = values.filter((i) => i.x !== null && i.x !== undefined).map((i) => {
     // if the x-axis is a timeseries, then convert it to an epoc int
     // for easier calculations
-    if(typeof i.x === "string"||i.x instanceof Date){
+    if (typeof i.x === 'string' || i.x instanceof Date) {
       return utils.getEpocFromDateString(i.x);
     }
     return i.x;

--- a/packages/carbon-graphs/src/js/helpers/axis.js
+++ b/packages/carbon-graphs/src/js/helpers/axis.js
@@ -1332,8 +1332,6 @@ const getUpperOutlierStretchFactor = (config, axis) => {
   const axisMidPoint = getMidPoint(config, axis);
   const upperStretchFactor = Math.abs((dataRangeMaxValue - axisMidPoint) / (axisMaxValue - axisMidPoint));
 
-  // console.log(upperStretchFactor);
-
   return upperStretchFactor > 1 ? upperStretchFactor : 1;
 };
 
@@ -1348,6 +1346,7 @@ const getUpperOutlierStretchFactor = (config, axis) => {
  * @returns {number} the stretch factor for the new lower limit
  */
 const getLowerOutlierStretchFactor = (config, axis) => {
+
   const axisMinValue = config.axis[axis].domain.lowerLimit;
   const axisMidPoint = getMidPoint(config, axis);
   const dataRangeMinValue = config.axis[axis].dataRange.min < axisMinValue ? config.axis[axis].dataRange.min : axisMinValue;
@@ -1582,12 +1581,14 @@ const getAxesDataRange = (
 
   config.axis[axis].dataRange.isRangeModified = isRangeModified;
 
-  if (isRangeModified) {
-    config.axis[axis].dataRange.oldMin = config.axis[axis].dataRange.min;
-    config.axis[axis].dataRange.oldMax = config.axis[axis].dataRange.max;
-    config.axis[axis].dataRange.min = curRange.min;
-    config.axis[axis].dataRange.max = curRange.max;
+  if (!isRangeModified) {
+    return;
   }
+
+  config.axis[axis].dataRange.oldMin = config.axis[axis].dataRange.min;
+  config.axis[axis].dataRange.oldMax = config.axis[axis].dataRange.max;
+  config.axis[axis].dataRange.min = curRange.min;
+  config.axis[axis].dataRange.max = curRange.max;
 };
 /**
  * Checks if provided input has valid axis type

--- a/packages/carbon-graphs/src/js/helpers/axis.js
+++ b/packages/carbon-graphs/src/js/helpers/axis.js
@@ -1346,7 +1346,6 @@ const getUpperOutlierStretchFactor = (config, axis) => {
  * @returns {number} the stretch factor for the new lower limit
  */
 const getLowerOutlierStretchFactor = (config, axis) => {
-
   const axisMinValue = config.axis[axis].domain.lowerLimit;
   const axisMidPoint = getMidPoint(config, axis);
   const dataRangeMinValue = config.axis[axis].dataRange.min < axisMinValue ? config.axis[axis].dataRange.min : axisMinValue;

--- a/packages/carbon-graphs/src/js/helpers/utils.js
+++ b/packages/carbon-graphs/src/js/helpers/utils.js
@@ -202,25 +202,43 @@ const isEqual = (a, b) => (isDate(a) || isDateInstance(a)
   ? isDateEqual(parseDateTime(a), parseDateTime(b))
   : a === b);
 /**
+ * Returns the date in epoc format.
+ *
+ * @private
+ * @param {string} dateISO - Date in ISO String format
+ * @returns {number} - epoc representation of given date
+ */
+ const getEpocFromDateString = (dateISO) => parseInt(new Date(dateISO).getTime());
+ /**
+ * Returns a date object based on the given epoc.
+ *
+ * @private
+ * @param {number} epocDate - Date as an epoc int
+ * @returns {object typeof Date} - Date object based on epoc
+ */
+  const getDateFromEpoc = (epocDate) => new Date(epocDate);
+/**
  * @enum {Function}
  */
 export default {
   deepClone,
-  isFunction,
-  isArray,
-  isEmptyArray,
-  isDefined,
-  isUndefined,
-  isEmpty,
-  notEmpty,
-  hasValue,
-  sanitize,
+  getEpocFromDateString,
+  getDateFromEpoc,
   getNumber,
-  isDate,
-  isNumber,
-  parseDateTime,
   getTime,
-  isDateInstance,
-  isEqual,
+  hasValue,
+  isArray,
   isBoolean,
+  isFunction,
+  isDate,
+  isDateInstance,
+  isDefined,
+  isEmptyArray,
+  isEmpty,
+  isEqual,
+  isNumber,
+  isUndefined,
+  notEmpty,
+  parseDateTime,
+  sanitize,
 };

--- a/packages/carbon-graphs/src/js/helpers/utils.js
+++ b/packages/carbon-graphs/src/js/helpers/utils.js
@@ -208,15 +208,15 @@ const isEqual = (a, b) => (isDate(a) || isDateInstance(a)
  * @param {string} dateISO - Date in ISO String format
  * @returns {number} - epoc representation of given date
  */
- const getEpocFromDateString = (dateISO) => parseInt(new Date(dateISO).getTime());
- /**
+const getEpocFromDateString = (dateISO) => parseInt(new Date(dateISO).getTime(), 10);
+/**
  * Returns a date object based on the given epoc.
  *
  * @private
  * @param {number} epocDate - Date as an epoc int
  * @returns {object typeof Date} - Date object based on epoc
  */
-  const getDateFromEpoc = (epocDate) => new Date(epocDate);
+const getDateFromEpoc = (epocDate) => new Date(epocDate);
 /**
  * @enum {Function}
  */

--- a/packages/carbon-graphs/tests/unit/controls/Line/LineLoad-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Line/LineLoad-spec.js
@@ -28,7 +28,7 @@ import {
   LINE_DASHED,
 } from '../../../../src/js/core/Shape/shapeDefinitions';
 
-fdescribe('Line - Load', () => {
+describe('Line - Load', () => {
   let graphDefault = null;
   let lineGraphContainer;
   beforeEach(() => {


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
This PR partially addresses UXPLATFORM-6904 by adding support for a timeseries axis for `config.axis.x.allowCalibration`. This is PR 1 of 2. PR #2 will add tests and documentation. 



<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-graphs-deployed-pr-45.herokuapp.com/ -->
https://terra-graphs-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
@cerner/carbon
