### PR TITLE
PairedResult - Add x-axis calibration for numerical x-axis

### DIFF
--- a/packages/carbon-graphs/src/js/controls/PairedResult/PairedResult.js
+++ b/packages/carbon-graphs/src/js/controls/PairedResult/PairedResult.js
@@ -51,18 +51,36 @@ import { validatePairedResultData } from '../../helpers/constructUtils';
  *
  * @private
  * @param {Array} values - Datapoint values
- * @param {string} axis - y or y2
  * @returns {object} - Contains min and max values for the data points
  */
-const calculateValuesRange = (values, axis = constants.Y_AXIS) => ({
-  [axis]: {
-    min: Math.min(
-      ...values.map((i) => Math.min(...Object.keys(i).map((j) => i[j].y))),
-    ),
-    max: Math.max(
-      ...values.map((i) => Math.max(...Object.keys(i).map((j) => i[j].y))),
-    ),
-  },
+const calculateValuesRangeYAxis = (values) => ({
+  min: Math.min(
+    ...values.map((i) => Math.min(...Object.keys(i).map((j) => i[j].y))),
+  ),
+  max: Math.max(
+    ...values.map((i) => Math.max(...Object.keys(i).map((j) => i[j].y))),
+  ),
+});
+
+/**
+ * @typedef {object} PairedResult
+ * @typedef {object} GraphContent
+ * @typedef {object} PairedResultConfig
+ */
+/**
+ * Calculates the min and max values for X Axis
+ *
+ * @private
+ * @param {Array} values - Datapoint values
+ * @returns {object} - Contains min and max values for the data points
+ */
+const calculateValuesRangeXAxis = (values) => ({
+  min: Math.min(
+    ...values.map((i) => Math.min(...Object.keys(i).map((j) => i[j].x))),
+  ),
+  max: Math.max(
+    ...values.map((i) => Math.max(...Object.keys(i).map((j) => i[j].x))),
+  ),
 });
 
 /**
@@ -146,10 +164,15 @@ class PairedResult extends GraphContent {
       constants.Y_AXIS,
     );
     this.config.values = filterPairedResultData(this.config.values);
-    this.valuesRange = calculateValuesRange(
+
+    this.valuesRange = {};
+    this.valuesRange.x = calculateValuesRangeXAxis(
       this.config.values,
-      this.config.yAxis,
     );
+    this.valuesRange[this.config.yAxis] = calculateValuesRangeYAxis(
+      this.config.values,
+    );
+
     this.dataTarget = {};
   }
 
@@ -363,10 +386,7 @@ class PairedResult extends GraphContent {
       .call(drawBox);
     pairedBoxSVG.exit().remove();
 
-    this.valuesRange = calculateValuesRange(
-      this.config.values,
-      this.config.yAxis,
-    );
+    this.valuesRange[this.config.yAxis] = calculateValuesRangeYAxis(this.config.values);
     this.resize(graph);
   }
 

--- a/packages/carbon-graphs/tests/unit/controls/PairedResult/PairedResultLoad-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/PairedResult/PairedResultLoad-spec.js
@@ -367,6 +367,88 @@ describe('Paired Result - Load', () => {
       );
       expect(point.length).toBe(0);
     });
+    it('does not update x axis range if allow calibration is disabled', () => {
+      const disableCalibrationInput = getAxes(axisDefault);
+      disableCalibrationInput.axis.x.allowCalibration = false;
+      disableCalibrationInput.axis.x.lowerLimit = 500;
+      const disableCalibrationGraph = new Graph(disableCalibrationInput);
+      input = getInput(valuesDefault, false, false);
+      disableCalibrationGraph.loadContent(new PairedResult(input));
+
+      expect(disableCalibrationGraph.config.axis.x.domain.upperLimit)
+        .toEqual(disableCalibrationInput.axis.x.upperLimit);
+      expect(disableCalibrationGraph.config.axis.x.domain.lowerLimit)
+        .toEqual(disableCalibrationInput.axis.x.lowerLimit);
+    });
+    it('does not update x axis range if allow calibration is undefined', () => {
+      const disableCalibrationInput = getAxes(axisDefault);
+      disableCalibrationInput.axis.x.lowerLimit = 500;
+      const disableCalibrationGraph = new Graph(disableCalibrationInput);
+      input = getInput(valuesDefault, false, false);
+      disableCalibrationGraph.loadContent(new PairedResult(input));
+
+      expect(disableCalibrationGraph.config.axis.x.domain.upperLimit)
+        .toEqual(disableCalibrationInput.axis.x.upperLimit);
+      expect(disableCalibrationGraph.config.axis.x.domain.lowerLimit)
+        .toEqual(disableCalibrationInput.axis.x.lowerLimit);
+    });
+    it('does not update x axis range if allow calibration is enabled and datapoints are within limits', () => {
+      const disableCalibrationInput = getAxes(axisDefault);
+      disableCalibrationInput.axis.x.allowCalibration = true;
+      disableCalibrationInput.axis.x.lowerLimit = 0;
+      disableCalibrationInput.axis.x.upperLimit = 500;
+      const disableCalibrationGraph = new Graph(disableCalibrationInput);
+      input = getInput(valuesDefault, false, false);
+      disableCalibrationGraph.loadContent(new PairedResult(input));
+
+      expect(disableCalibrationGraph.config.axis.x.domain.upperLimit).toEqual(500);
+      expect(disableCalibrationGraph.config.axis.x.domain.lowerLimit).toEqual(0);
+    });
+    it('updates x axis range if allow calibration is enabled and datapoints are within limits', () => {
+      const disableCalibrationInput = getAxes(axisDefault);
+      disableCalibrationInput.axis.x.allowCalibration = true;
+      disableCalibrationInput.axis.x.lowerLimit = 30;
+      disableCalibrationInput.axis.x.upperLimit = 35;
+      const disableCalibrationGraph = new Graph(disableCalibrationInput);
+      input = getInput(
+        [
+          {
+            high: {
+              x: 25,
+              y: 350,
+            },
+            mid: {
+              x: 25,
+              y: 146,
+            },
+            low: {
+              x: 25,
+              y: 75,
+            },
+          },
+          {
+            high: {
+              x: 45,
+              y: 110,
+            },
+            mid: {
+              x: 45,
+              y: 70,
+            },
+            low: {
+              x: 45,
+              y: 30,
+            },
+          },
+        ],
+        false,
+        false,
+      );
+      disableCalibrationGraph.loadContent(new PairedResult(input));
+
+      expect(disableCalibrationGraph.config.axis.x.domain.upperLimit).toEqual(46);
+      expect(disableCalibrationGraph.config.axis.x.domain.lowerLimit).toEqual(24);
+    });
     describe('when invalid data is passed', () => {
       describe('for paired result high,', () => {
         it('should remove datapoint when undefined is passed', () => {


### PR DESCRIPTION
### Summary
This PR updates the paired result graph  to support the `axis.x.allowCalibration` prop for a numerical x-axis.

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-graphs-deployed-pr-45.herokuapp.com/ -->
https://terra-graphs-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
@cerner/carbon
