### PR TITLE
Scatter Graph - Update to support the allowXCallibration prop

### DIFF
--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added
   * Added allowCalibration support for the x-axis on a line graph.
   * Finished implementation for `config.axis.x.allowCalibration` for a paired result graph with a numerical x-axis.
+  * Finished implementation for `config.axis.x.allowCalibration` for a scatter graph with a numerical and timeseries x-axis.
 
 ## 2.21.0 - (February 15, 2022)
 
@@ -28,7 +29,7 @@
 
 * Changed
   * Updated logic for displaying multiple zeros on Y and Y2 axis ticks.
-  
+
 ## 2.20.0 - (November 16, 2021)
 
 * Changed
@@ -65,7 +66,7 @@
 * Changed
   * Fixed bug causing the goal line element to prevent clicking on the bar graph underneath.
 
-  
+
 ## 2.17.1 - (May 11, 2021)
 
 * Changed
@@ -76,14 +77,14 @@
 
 ## 2.17.0 - (April 27, 2021)
 
-* Changed 
+* Changed
   * Fixed rendering of timeline graph when it is rendered below another graph.
   * Fixed Y-axis and y2-axis icons not updating during reflow.
   * Updated `packages/carbon-graphs/README.md` so that links point to updated documentation path.
 
 * Added
   * Added datasets for building graphs in terra-graphs package.
-  
+
 ## 2.16.3 - (March 16, 2021)
 
 * Changed
@@ -94,7 +95,7 @@
 
 * Added
   * Added `reflowMultipleDatasets` to allow users to send in multiple datasets per graph instance.
-  
+
 * Changed
   * Fixed axis label bug occuring with reflow.
   * Added deprecation warning for `reflow`.

--- a/packages/carbon-graphs/src/js/controls/Scatter/Scatter.js
+++ b/packages/carbon-graphs/src/js/controls/Scatter/Scatter.js
@@ -68,7 +68,7 @@ const calculateValuesRangeYAxis = (values) => {
  *
  * @private
  * @param {Array} values - Datapoint values
- * @returns {object} - Contains min and max values for the data points for Y and Y2 axis
+ * @returns {object} - Contains min and max values for the data points for x-axis
  */
 const calculateValuesRangeXAxis = (values) => {
   const xAxisValuesList = values.filter((i) => i.x !== null && i.x !== undefined).map((i) => {
@@ -266,7 +266,7 @@ class Scatter extends GraphContent {
       .remove();
 
     updateShapesDuringReflow(graph, graphData, this);
-    this.valuesRange[this.config.yAxis] = calculateValuesRangeYAxis(this.config.values, this.config.yAxis);
+    this.valuesRange[this.config.yAxis] = calculateValuesRangeYAxis(this.config.values);
   }
 
   /**

--- a/packages/carbon-graphs/tests/unit/controls/Scatter/ScatterLoad-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Scatter/ScatterLoad-spec.js
@@ -297,56 +297,54 @@ describe('Scatter - Load', () => {
       );
     });
     it('does not update x axis range if allow calibration is disabled', () => {
-      const disableCalibrationInput = getAxes(axisDefault);
-      disableCalibrationInput.axis.x.allowCalibration = false;
-      disableCalibrationInput.axis.x.lowerLimit = 50;
-      const disableCalibrationGraph = new Graph(disableCalibrationInput);
+      const graphConfig = getAxes(axisDefault);
+      graphConfig.axis.x.allowCalibration = false;
+      const graphInstance = new Graph(graphConfig);
       input = getInput(valuesDefault, false, false);
-      disableCalibrationGraph.loadContent(new Scatter(input));
+      graphInstance.loadContent(new Scatter(input));
 
-      expect(disableCalibrationGraph.config.axis.x.domain.upperLimit)
-        .toEqual(disableCalibrationInput.axis.x.upperLimit);
-      expect(disableCalibrationGraph.config.axis.x.domain.lowerLimit)
-        .toEqual(disableCalibrationInput.axis.x.lowerLimit);
+      expect(graphInstance.config.axis.x.domain.upperLimit)
+        .toEqual(graphConfig.axis.x.upperLimit);
+      expect(graphInstance.config.axis.x.domain.lowerLimit)
+        .toEqual(graphConfig.axis.x.lowerLimit);
     });
     it('does not update x axis range by default if allowCalibration is undefined', () => {
-      const disableCalibrationInput = getAxes(axisDefault);
-      disableCalibrationInput.axis.x.allowCalibration = undefined;
-      disableCalibrationInput.axis.x.lowerLimit = 50;
-      const disableCalibrationGraph = new Graph(disableCalibrationInput);
+      const graphConfig = getAxes(axisDefault);
+      graphConfig.axis.x.allowCalibration = undefined;
+      const graphInstance = new Graph(graphConfig);
       input = getInput(valuesDefault, false, false);
-      disableCalibrationGraph.loadContent(new Scatter(input));
+      graphInstance.loadContent(new Scatter(input));
 
-      expect(disableCalibrationGraph.config.axis.x.domain.upperLimit)
-        .toEqual(disableCalibrationInput.axis.x.upperLimit);
-      expect(disableCalibrationGraph.config.axis.x.domain.lowerLimit)
-        .toEqual(disableCalibrationInput.axis.x.lowerLimit);
+      expect(graphInstance.config.axis.x.domain.upperLimit)
+        .toEqual(graphConfig.axis.x.upperLimit);
+      expect(graphInstance.config.axis.x.domain.lowerLimit)
+        .toEqual(graphConfig.axis.x.lowerLimit);
     });
     it('does not x axis range if allowCalibration is true and datapoints are within limits', () => {
-      const disableCalibrationInput = getAxes(axisDefault);
-      disableCalibrationInput.axis.x.allowCalibration = true;
-      disableCalibrationInput.axis.x.lowerLimit = 20;
-      disableCalibrationInput.axis.x.upperLimit = 70;
+      const graphConfig = getAxes(axisDefault);
+      graphConfig.axis.x.allowCalibration = true;
+      graphConfig.axis.x.lowerLimit = 20;
+      graphConfig.axis.x.upperLimit = 70;
 
-      const disableCalibrationGraph = new Graph(disableCalibrationInput);
+      const graphInstance = new Graph(graphConfig);
       input = getInput(valuesDefault, false, false);
-      disableCalibrationGraph.loadContent(new Scatter(input));
+      graphInstance.loadContent(new Scatter(input));
 
-      expect(disableCalibrationGraph.config.axis.x.domain.lowerLimit).toEqual(20);
-      expect(disableCalibrationGraph.config.axis.x.domain.upperLimit).toEqual(70);
+      expect(graphInstance.config.axis.x.domain.lowerLimit).toEqual(20);
+      expect(graphInstance.config.axis.x.domain.upperLimit).toEqual(70);
     });
     it('updates x axis range if allowCalibration is true and datapoints exceed or are equal to limits', () => {
-      const disableCalibrationInput = getAxes(axisDefault);
-      disableCalibrationInput.axis.x.allowCalibration = true;
-      disableCalibrationInput.axis.x.lowerLimit = 30;
-      disableCalibrationInput.axis.x.upperLimit = 45;
+      const graphConfig = getAxes(axisDefault);
+      graphConfig.axis.x.allowCalibration = true;
+      graphConfig.axis.x.lowerLimit = 30;
+      graphConfig.axis.x.upperLimit = 45;
 
-      const disableCalibrationGraph = new Graph(disableCalibrationInput);
+      const graphInstance = new Graph(graphConfig);
       input = getInput(valuesDefault, false, false);
-      disableCalibrationGraph.loadContent(new Scatter(input));
+      graphInstance.loadContent(new Scatter(input));
 
-      expect(disableCalibrationGraph.config.axis.x.domain.lowerLimit).toEqual(24);
-      expect(disableCalibrationGraph.config.axis.x.domain.upperLimit).toEqual(46);
+      expect(graphInstance.config.axis.x.domain.lowerLimit).toEqual(24);
+      expect(graphInstance.config.axis.x.domain.upperLimit).toEqual(46);
     });
     it('does not update the timeseries x axis range if allowCalibration is true and datapoints are within limits', () => {
       const expectedDateLowerLimit = new Date(2016, 1, 1);

--- a/packages/carbon-graphs/tests/unit/controls/Scatter/ScatterLoad-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Scatter/ScatterLoad-spec.js
@@ -320,7 +320,7 @@ describe('Scatter - Load', () => {
       expect(graphInstance.config.axis.x.domain.lowerLimit)
         .toEqual(graphConfig.axis.x.lowerLimit);
     });
-    it('does not x axis range if allowCalibration is true and datapoints are within limits', () => {
+    it('does not update x axis range if allowCalibration is true and datapoints are within limits', () => {
       const graphConfig = getAxes(axisDefault);
       graphConfig.axis.x.allowCalibration = true;
       graphConfig.axis.x.lowerLimit = 20;

--- a/packages/carbon-graphs/tests/unit/controls/Scatter/ScatterLoad-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Scatter/ScatterLoad-spec.js
@@ -296,6 +296,100 @@ describe('Scatter - Load', () => {
         input.key,
       );
     });
+    it('does not update x axis range if allow calibration is disabled', () => {
+      const disableCalibrationInput = getAxes(axisDefault);
+      disableCalibrationInput.axis.x.allowCalibration = false;
+      disableCalibrationInput.axis.x.lowerLimit = 50;
+      const disableCalibrationGraph = new Graph(disableCalibrationInput);
+      input = getInput(valuesDefault, false, false);
+      disableCalibrationGraph.loadContent(new Scatter(input));
+
+      expect(disableCalibrationGraph.config.axis.x.domain.upperLimit)
+        .toEqual(disableCalibrationInput.axis.x.upperLimit);
+      expect(disableCalibrationGraph.config.axis.x.domain.lowerLimit)
+        .toEqual(disableCalibrationInput.axis.x.lowerLimit);
+    });
+    it('does not update x axis range by default if allowCalibration is undefined', () => {
+      const disableCalibrationInput = getAxes(axisDefault);
+      disableCalibrationInput.axis.x.allowCalibration = undefined;
+      disableCalibrationInput.axis.x.lowerLimit = 50;
+      const disableCalibrationGraph = new Graph(disableCalibrationInput);
+      input = getInput(valuesDefault, false, false);
+      disableCalibrationGraph.loadContent(new Scatter(input));
+
+      expect(disableCalibrationGraph.config.axis.x.domain.upperLimit)
+        .toEqual(disableCalibrationInput.axis.x.upperLimit);
+      expect(disableCalibrationGraph.config.axis.x.domain.lowerLimit)
+        .toEqual(disableCalibrationInput.axis.x.lowerLimit);
+    });
+    it('does not x axis range if allowCalibration is true and datapoints are within limits', () => {
+      const disableCalibrationInput = getAxes(axisDefault);
+      disableCalibrationInput.axis.x.allowCalibration = true;
+      disableCalibrationInput.axis.x.lowerLimit = 20;
+      disableCalibrationInput.axis.x.upperLimit = 70;
+
+      const disableCalibrationGraph = new Graph(disableCalibrationInput);
+      input = getInput(valuesDefault, false, false);
+      disableCalibrationGraph.loadContent(new Scatter(input));
+
+      expect(disableCalibrationGraph.config.axis.x.domain.lowerLimit).toEqual(20);
+      expect(disableCalibrationGraph.config.axis.x.domain.upperLimit).toEqual(70);
+    });
+    it('updates x axis range if allowCalibration is true and datapoints exceed or are equal to limits', () => {
+      const disableCalibrationInput = getAxes(axisDefault);
+      disableCalibrationInput.axis.x.allowCalibration = true;
+      disableCalibrationInput.axis.x.lowerLimit = 30;
+      disableCalibrationInput.axis.x.upperLimit = 45;
+
+      const disableCalibrationGraph = new Graph(disableCalibrationInput);
+      input = getInput(valuesDefault, false, false);
+      disableCalibrationGraph.loadContent(new Scatter(input));
+
+      expect(disableCalibrationGraph.config.axis.x.domain.lowerLimit).toEqual(24);
+      expect(disableCalibrationGraph.config.axis.x.domain.upperLimit).toEqual(46);
+    });
+    it('does not update the timeseries x axis range if allowCalibration is true and datapoints are within limits', () => {
+      const expectedDateLowerLimit = new Date(2016, 1, 1);
+      const expectedDateUpperLimit = new Date(2016, 5, 15);
+
+      const graphConfig = getAxes(axisTimeSeries);
+      graphConfig.axis.x.allowCalibration = true;
+      graphConfig.axis.x.lowerLimit = expectedDateLowerLimit.toISOString();
+      graphConfig.axis.x.upperLimit = expectedDateUpperLimit.toISOString();
+
+      const graphInstance = new Graph(graphConfig);
+      input = getInput(valuesTimeSeries, false, false);
+      graphInstance.loadContent(new Scatter(input));
+
+      expect(graphInstance.config.axis.x.domain.lowerLimit).toEqual(expectedDateLowerLimit);
+      expect(graphInstance.config.axis.x.domain.upperLimit).toEqual(expectedDateUpperLimit);
+    });
+    it('updates the timeseries x axis range if allowCalibration is true and datapoints exceed limits', () => {
+      const graphConfig = getAxes(axisTimeSeries);
+      graphConfig.axis.x.allowCalibration = true;
+      graphConfig.axis.x.lowerLimit = new Date(2016, 3, 10).toISOString();
+      graphConfig.axis.x.upperLimit = new Date(2016, 4, 25).toISOString();
+
+      const graphInstance = new Graph(graphConfig);
+      input = getInput(valuesTimeSeries, false, false);
+      graphInstance.loadContent(new Scatter(input));
+
+      expect(graphInstance.config.axis.x.domain.lowerLimit.toISOString()).toEqual('2016-01-28T10:48:00.000Z');
+      expect(graphInstance.config.axis.x.domain.upperLimit.toISOString()).toEqual('2016-06-09T13:12:00.000Z');
+    });
+    it('updates the timeseries x axis range if allowCalibration is true and datapoints are equal to limits', () => {
+      const graphConfig = getAxes(axisTimeSeries);
+      graphConfig.axis.x.allowCalibration = true;
+      graphConfig.axis.x.lowerLimit = '2016-02-03T12:00:00Z';
+      graphConfig.axis.x.upperLimit = '2016-06-03T12:00:00Z';
+
+      const graphInstance = new Graph(graphConfig);
+      input = getInput(valuesTimeSeries, false, false);
+      graphInstance.loadContent(new Scatter(input));
+
+      expect(graphInstance.config.axis.x.domain.lowerLimit.toISOString()).toEqual('2016-01-28T10:48:00.000Z');
+      expect(graphInstance.config.axis.x.domain.upperLimit.toISOString()).toEqual('2016-06-09T13:12:00.000Z');
+    });
     describe('when clicked on a data point', () => {
       it('does not do anything if no onClick callback is provided', (done) => {
         graphDefault.destroy();


### PR DESCRIPTION
[UXPLATFORM-6842](https://jira2.cerner.com/browse/UXPLATFORM-6824)
===

### Summary
Allows a scatter graph to be configured with the 'Allow Callibration' preference. This allows the user to see all the data points without it being cut off.

### Deployment Link
https://terra-graphs-deployed-pr-#.herokuapp.com/

### Testing
`npm run karma`
![Screen Shot 2022-08-31 at 11 47 35 AM](https://user-images.githubusercontent.com/8482248/187757874-b33902a6-4752-4a35-858a-1b3ac3886bcb.png)

Thank you for contributing to Terra.
@cerner/terra
@cerner/carbon