### PR TITLE
Paired Result - Add x-axis calibration for timeseries x-axis

### DIFF
--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 * Added
   * Added allowCalibration support for the x-axis on a line graph.
-  * Finished implementation for `config.axis.x.allowCalibration` for a paired result graph with a numerical x-axis.
-  * Finished implementation for `config.axis.x.allowCalibration` for a paired result graph with a timeseries x-axis.
+  * Finished implementation for `config.axis.x.allowCalibration` for a paired result graph with a numerical and timeseries x-axis.
 
 ## 2.21.0 - (February 15, 2022)
 

--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added
   * Added allowCalibration support for the x-axis on a line graph.
   * Finished implementation for `config.axis.x.allowCalibration` for a paired result graph with a numerical x-axis.
+  * Finished implementation for `config.axis.x.allowCalibration` for a paired result graph with a timeseries x-axis.
 
 ## 2.21.0 - (February 15, 2022)
 

--- a/packages/carbon-graphs/src/js/controls/PairedResult/PairedResult.js
+++ b/packages/carbon-graphs/src/js/controls/PairedResult/PairedResult.js
@@ -78,7 +78,14 @@ const calculateValuesRangeYAxis = (values) => {
  * @returns {object} - Contains min and max values for the data points
  */
 const calculateValuesRangeXAxis = (values) => {
-  const xAxisValuesList = values.map((i) => Object.keys(i).map((j) => i[j].x));
+  const xAxisValuesList = values.map((i) => Object.keys(i).map((j) => {
+    // if the x-axis is a timeseries, then convert it to an epoc int
+    // for easier calculations
+    if (typeof i[j].x === 'string' || i[j].x instanceof Date) {
+      return utils.getEpocFromDateString(i[j].x);
+    }
+    return i[j].x;
+  }));
   return {
     min: Math.min(
       ...xAxisValuesList.map((i) => Math.min(...i)),

--- a/packages/carbon-graphs/tests/unit/controls/PairedResult/PairedResultLoad-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/PairedResult/PairedResultLoad-spec.js
@@ -428,6 +428,48 @@ describe('Paired Result - Load', () => {
       expect(graphInstance.config.axis.x.domain.upperLimit).toEqual(491.25);
       expect(graphInstance.config.axis.x.domain.lowerLimit).toEqual(23.75);
     });
+    it('does not update the timeseries x axis range if allowCalibration is true and datapoints are within limits', () => {
+      const expectedDateLowerLimit = new Date(2016, 7, 1);
+      const expectedDateUpperLimit = new Date(2016, 10, 1);
+
+      const graphConfig = getAxes(axisTimeSeries);
+      graphConfig.axis.x.allowCalibration = true;
+      graphConfig.axis.x.lowerLimit = expectedDateLowerLimit.toISOString();
+      graphConfig.axis.x.upperLimit = expectedDateUpperLimit.toISOString();
+
+      const graphInstance = new Graph(graphConfig);
+      input = getInput(valuesTimeSeries, false, false);
+      graphInstance.loadContent(new PairedResult(input));
+
+      expect(graphInstance.config.axis.x.domain.lowerLimit).toEqual(expectedDateLowerLimit);
+      expect(graphInstance.config.axis.x.domain.upperLimit).toEqual(expectedDateUpperLimit);
+    });
+    it('updates the timeseries x axis range if allowCalibration is true and datapoints exceed limits', () => {
+      const graphConfig = getAxes(axisTimeSeries);
+      graphConfig.axis.x.allowCalibration = true;
+      graphConfig.axis.x.lowerLimit = new Date(2016, 8, 1).toISOString();
+      graphConfig.axis.x.upperLimit = new Date(2016, 9, 1).toISOString();
+
+      const graphInstance = new Graph(graphConfig);
+      input = getInput(valuesTimeSeries, false, false);
+      graphInstance.loadContent(new PairedResult(input));
+
+      expect(graphInstance.config.axis.x.domain.lowerLimit.toISOString()).toEqual('2016-08-14T07:57:00.000Z');
+      expect(graphInstance.config.axis.x.domain.upperLimit.toISOString()).toEqual('2016-10-23T01:03:00.000Z');
+    });
+    it('updates the timeseries x axis range if allowCalibration is true and datapoints are equal to limits', () => {
+      const graphConfig = getAxes(axisTimeSeries);
+      graphConfig.axis.x.allowCalibration = true;
+      graphConfig.axis.x.lowerLimit = '2016-08-17T12:00:00Z';
+      graphConfig.axis.x.upperLimit = '2016-10-17T09:00:00Z';
+
+      const graphInstance = new Graph(graphConfig);
+      input = getInput(valuesTimeSeries, false, false);
+      graphInstance.loadContent(new PairedResult(input));
+
+      expect(graphInstance.config.axis.x.domain.lowerLimit.toISOString()).toEqual('2016-08-14T07:57:00.000Z');
+      expect(graphInstance.config.axis.x.domain.upperLimit.toISOString()).toEqual('2016-10-23T01:03:00.000Z');
+    });
     describe('when invalid data is passed', () => {
       describe('for paired result high,', () => {
         it('should remove datapoint when undefined is passed', () => {


### PR DESCRIPTION
### Summary
This PR updates the paired result graph to support the axis.x.allowCalibration prop for a timeseries x-axis. (UXPLATFORM-6991)

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-graphs-deployed-pr-45.herokuapp.com/ -->
https://terra-graphs-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
@cerner/carbon
