### PR TITLE
Bar Graph - Update to support the allowXCallibration prop

### DIFF
--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Added allowCalibration support for the x-axis on a line graph.
   * Finished implementation for `config.axis.x.allowCalibration` for a paired result graph with a numerical x-axis.
   * Finished implementation for `config.axis.x.allowCalibration` for a scatter graph with a numerical and timeseries x-axis.
+  * Finished implementation for `config.axis.x.allowCalibration` for a bar graph with a numerical and timeseries x-axis.
 
 ## 2.21.0 - (February 15, 2022)
 

--- a/packages/carbon-graphs/src/js/controls/Bar/Bar.js
+++ b/packages/carbon-graphs/src/js/controls/Bar/Bar.js
@@ -35,21 +35,53 @@ import {
 } from './helpers/translateHelpers';
 
 /**
+ * @typedef {object} Bar
+ * @typedef {object} GraphContent
+ * @typedef {object} BarConfig
+ */
+/**
  * Calculates the min and max values for Y Axis or Y2 Axis
  *
  * @private
  * @param {Array} values - Datapoint values
- * @param {string} axis - y or y2
  * @returns {object} - Contains min and max values for the data points
  */
-const calculateValuesRange = (values, axis = constants.Y_AXIS) => {
+const calculateValuesRangeYAxis = (values) => {
   const min = Math.min(...values.map((i) => i.y));
   const max = Math.max(...values.map((i) => i.y));
   return {
-    [axis]: {
-      min: min < 0 ? min : 0,
-      max: max > 0 ? max : 0,
-    },
+    min: min < 0 ? min : 0,
+    max: max > 0 ? max : 0,
+  };
+};
+
+/**
+ * @typedef {object} Bar
+ * @typedef {object} GraphContent
+ * @typedef {object} BarConfig
+ */
+/**
+ * Calculates the min and max values for X-axis.
+ * First we filter out values that are `null`, this is a result of
+ * datapoint being part of being in a non-contiguous series and then we
+ * get the min and max values for the X-axis domain.
+ *
+ * @private
+ * @param {Array} values - Datapoint values
+ * @returns {object} - Contains min and max values for the data points for x-axis
+ */
+const calculateValuesRangeXAxis = (values) => {
+  const xAxisValuesList = values.filter((i) => i.x !== null && i.x !== undefined).map((i) => {
+    // if the x-axis is a timeseries, then convert it to an epoc int
+    // for easier calculations
+    if (typeof i.x === 'string' || i.x instanceof Date) {
+      return utils.getEpocFromDateString(i.x);
+    }
+    return i.x;
+  });
+  return {
+    min: Math.min(...xAxisValuesList),
+    max: Math.max(...xAxisValuesList),
   };
 };
 
@@ -109,9 +141,14 @@ class Bar extends GraphContent {
       constants.Y_AXIS,
     );
     this.config.axisPadding = false;
-    this.valuesRange = calculateValuesRange(
+    this.valuesRange = {};
+
+    this.valuesRange.x = calculateValuesRangeXAxis(
       this.config.values,
-      this.config.yAxis,
+    );
+
+    this.valuesRange[this.config.yAxis] = calculateValuesRangeYAxis(
+      this.config.values,
     );
   }
 
@@ -308,10 +345,7 @@ class Bar extends GraphContent {
       this.dataTarget.axisInfoRow,
     );
     this.resize(graph);
-    this.valuesRange = calculateValuesRange(
-      this.config.values,
-      this.config.yAxis,
-    );
+    this.valuesRange[this.config.yAxis] = calculateValuesRangeYAxis(this.config.values);
     this.resize(graph);
   }
 

--- a/packages/carbon-graphs/src/js/controls/Bar/Bar.js
+++ b/packages/carbon-graphs/src/js/controls/Bar/Bar.js
@@ -56,21 +56,13 @@ const calculateValuesRangeYAxis = (values) => {
 };
 
 /**
- * @typedef {object} Bar
- * @typedef {object} GraphContent
- * @typedef {object} BarConfig
- */
-/**
- * Calculates the min and max values for X-axis.
- * First we filter out values that are `null`, this is a result of
- * datapoint being part of being in a non-contiguous series and then we
- * get the min and max values for the X-axis domain.
- *
+ * Calculates the min and max values for the x axis.
  * @private
  * @param {Array} values - Datapoint values
- * @returns {object} - Contains min and max values for the data points for x-axis
+ * @returns {object} - Contains min and max values for the data points for the x axis
  */
 const calculateValuesRangeXAxis = (values) => {
+  // null values are filtered out first
   const xAxisValuesList = values.filter((i) => i.x !== null && i.x !== undefined).map((i) => {
     // if the x-axis is a timeseries, then convert it to an epoc int
     // for easier calculations

--- a/packages/carbon-graphs/tests/unit/controls/Bar/BarLoad-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Bar/BarLoad-spec.js
@@ -569,7 +569,7 @@ describe('Bar - Load lifecycle', () => {
       expect(graphInstance.config.axis.x.domain.lowerLimit).toEqual(0);
       expect(graphInstance.config.axis.x.domain.upperLimit).toEqual(6);
     });
-    fit('updates x axis range if allowCalibration is true and datapoints exceed or are equal to limits', () => {
+    it('updates x axis range if allowCalibration is true and datapoints exceed or are equal to limits', () => {
       const graphConfig = getAxes(axisDefault);
       graphConfig.axis.x.allowCalibration = true;
       graphConfig.axis.x.lowerLimit = 2;

--- a/packages/carbon-graphs/tests/unit/controls/Bar/BarLoad-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Bar/BarLoad-spec.js
@@ -532,6 +532,98 @@ describe('Bar - Load lifecycle', () => {
         });
       });
     });
+    it('does not update x axis range if allow calibration is disabled', () => {
+      const graphConfig = getAxes(axisDefault);
+      graphConfig.axis.x.allowCalibration = false;
+      const graphInstance = new Graph(graphConfig);
+      input = getInput(valuesDefault, false, false);
+      graphInstance.loadContent(new Bar(input));
+
+      expect(graphInstance.config.axis.x.domain.upperLimit)
+        .toEqual(graphConfig.axis.x.upperLimit);
+      expect(graphInstance.config.axis.x.domain.lowerLimit)
+        .toEqual(graphConfig.axis.x.lowerLimit);
+    });
+    it('does not update x axis range by default if allowCalibration is undefined', () => {
+      const graphConfig = getAxes(axisDefault);
+      graphConfig.axis.x.allowCalibration = undefined;
+      const graphInstance = new Graph(graphConfig);
+      input = getInput(valuesDefault, false, false);
+      graphInstance.loadContent(new Bar(input));
+
+      expect(graphInstance.config.axis.x.domain.upperLimit)
+        .toEqual(graphConfig.axis.x.upperLimit);
+      expect(graphInstance.config.axis.x.domain.lowerLimit)
+        .toEqual(graphConfig.axis.x.lowerLimit);
+    });
+    it('does not update x axis range if allowCalibration is true and datapoints are within limits', () => {
+      const graphConfig = getAxes(axisDefault);
+      graphConfig.axis.x.allowCalibration = true;
+      graphConfig.axis.x.lowerLimit = 0;
+      graphConfig.axis.x.upperLimit = 6;
+
+      const graphInstance = new Graph(graphConfig);
+      input = getInput(valuesDefault, false, false);
+      graphInstance.loadContent(new Bar(input));
+
+      expect(graphInstance.config.axis.x.domain.lowerLimit).toEqual(0);
+      expect(graphInstance.config.axis.x.domain.upperLimit).toEqual(6);
+    });
+    fit('updates x axis range if allowCalibration is true and datapoints exceed or are equal to limits', () => {
+      const graphConfig = getAxes(axisDefault);
+      graphConfig.axis.x.allowCalibration = true;
+      graphConfig.axis.x.lowerLimit = 2;
+      graphConfig.axis.x.upperLimit = 2.5;
+
+      const graphInstance = new Graph(graphConfig);
+      input = getInput(valuesDefault, false, false);
+      graphInstance.loadContent(new Bar(input));
+
+      expect(graphInstance.config.axis.x.domain.lowerLimit).toEqual(0.9);
+      expect(graphInstance.config.axis.x.domain.upperLimit).toEqual(3.1);
+    });
+    it('does not update the timeseries x axis range if allowCalibration is true and datapoints are within limits', () => {
+      const expectedDateLowerLimit = new Date(2016, 1, 1);
+      const expectedDateUpperLimit = new Date(2016, 5, 15);
+
+      const graphConfig = getAxes(axisTimeSeries);
+      graphConfig.axis.x.allowCalibration = true;
+      graphConfig.axis.x.lowerLimit = expectedDateLowerLimit.toISOString();
+      graphConfig.axis.x.upperLimit = expectedDateUpperLimit.toISOString();
+
+      const graphInstance = new Graph(graphConfig);
+      input = getInput(valuesTimeSeries, false, false);
+      graphInstance.loadContent(new Bar(input));
+
+      expect(graphInstance.config.axis.x.domain.lowerLimit).toEqual(expectedDateLowerLimit);
+      expect(graphInstance.config.axis.x.domain.upperLimit).toEqual(expectedDateUpperLimit);
+    });
+    it('updates the timeseries x axis range if allowCalibration is true and datapoints exceed limits', () => {
+      const graphConfig = getAxes(axisTimeSeries);
+      graphConfig.axis.x.allowCalibration = true;
+      graphConfig.axis.x.lowerLimit = new Date(2016, 3, 10).toISOString();
+      graphConfig.axis.x.upperLimit = new Date(2016, 4, 25).toISOString();
+
+      const graphInstance = new Graph(graphConfig);
+      input = getInput(valuesTimeSeries, false, false);
+      graphInstance.loadContent(new Bar(input));
+
+      expect(graphInstance.config.axis.x.domain.lowerLimit.toISOString()).toEqual('2016-01-28T10:48:00.000Z');
+      expect(graphInstance.config.axis.x.domain.upperLimit.toISOString()).toEqual('2016-06-09T13:12:00.000Z');
+    });
+    it('updates the timeseries x axis range if allowCalibration is true and datapoints are equal to limits', () => {
+      const graphConfig = getAxes(axisTimeSeries);
+      graphConfig.axis.x.allowCalibration = true;
+      graphConfig.axis.x.lowerLimit = '2016-02-03T12:00:00Z';
+      graphConfig.axis.x.upperLimit = '2016-06-03T12:00:00Z';
+
+      const graphInstance = new Graph(graphConfig);
+      input = getInput(valuesTimeSeries, false, false);
+      graphInstance.loadContent(new Bar(input));
+
+      expect(graphInstance.config.axis.x.domain.lowerLimit.toISOString()).toEqual('2016-01-28T10:48:00.000Z');
+      expect(graphInstance.config.axis.x.domain.upperLimit.toISOString()).toEqual('2016-06-09T13:12:00.000Z');
+    });
     describe('when clicked on a data point', () => {
       afterEach(() => {
         graphDefault.destroy();


### PR DESCRIPTION
[UXPLATFORM-6814](https://jira2.cerner.com/browse/UXPLATFORM-6814)
===

### Summary
Allows a bar graph to be configured with the 'Allow Callibration' preference. This allows the user to see all the data points without it being cut off.

### Deployment Link
https://terra-graphs-deployed-pr-#.herokuapp.com/

### Testing
`npm run karma`
<img width="829" alt="Screen Shot 2022-09-07 at 1 20 27 PM" src="https://user-images.githubusercontent.com/8482248/188969784-1c4c1586-1110-43a6-92e2-fc24cfe87994.png">

Thank you for contributing to Terra.
@cerner/terra
@cerner/carbon