### PR TITLE
Fix infinite padding on multiple unload/load where maximum datapoint is zero

### DIFF
--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Fixed
-  * Fix infinite padding in line graphs reflow where maximum y axis value is zero
+  * Fixed infinite padding in line graphs on multiple unload/load where maximum datapoint is zero
   * Fixed tick lines overflowing outside the grid container when using custom tick values.
 
 * Changed

--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Fixed
-  * Fixed infinite padding in line graphs on multiple unload/load where maximum datapoint is zero
+  * Fixed infinite padding in line graphs on multiple unload/load where maximum datapoint is zero.
   * Fixed tick lines overflowing outside the grid container when using custom tick values.
 
 * Changed

--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Fixed
+  * Fix infinite padding in line graphs reflow where maximum y axis value is zero
   * Fixed tick lines overflowing outside the grid container when using custom tick values.
 
 * Changed

--- a/packages/carbon-graphs/dev-site/serve/serve-static.js
+++ b/packages/carbon-graphs/dev-site/serve/serve-static.js
@@ -1,6 +1,6 @@
+const fs = require('fs');
 const express = require('express');
 const rateLimit = require('express-rate-limit');
-const fs = require('fs');
 
 const displayServer = (localAddress) => {
   console.log('[serve-static] Server started listening at');

--- a/packages/carbon-graphs/src/js/helpers/axis.js
+++ b/packages/carbon-graphs/src/js/helpers/axis.js
@@ -1593,7 +1593,7 @@ const getAxesDataRange = (
   const prevMax = config.axis[axis].dataRange.oldMax;
   let isRangeModified;
 
-  if (prevMin === 0) {
+  if (prevMin === 0 || prevMax === 0) {
     isRangeModified = !(prevMin <= curRange.min || prevMax >= curRange.max);
   } else {
     isRangeModified = !(prevMin && prevMax)

--- a/packages/carbon-graphs/tests/unit/controls/Line/LinePanning-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Line/LinePanning-spec.js
@@ -450,5 +450,47 @@ describe('Line - Panning', () => {
         expect(graphDefault.config.axis.y.dataRange.isRangeModified).toEqual(false);
       });
     });
+    describe('when the same data is passed on multiple clicks of panning and Minimum Data Range is 0', () => {
+      it('Range modified should be false', () => {
+        const panData = {
+          key: 'uid_1',
+          values: [
+            {
+              x: '2016-03-03T12:00:00Z',
+              y: 0,
+            },
+            {
+              x: '2016-04-03T12:00:00Z',
+              y: 20,
+            },
+          ],
+        };
+        graphDefault.reflow(panData);
+        graphDefault.reflow(panData);
+        graphDefault.reflow(panData);
+        expect(graphDefault.config.axis.y.dataRange.isRangeModified).toEqual(false);
+      });
+    });
+    describe('when the same data is passed on multiple clicks of panning and Maximum Data Range is 0', () => {
+      it('Range modified should be false', () => {
+        const panData = {
+          key: 'uid_1',
+          values: [
+            {
+              x: '2016-03-03T12:00:00Z',
+              y: 0,
+            },
+            {
+              x: '2016-04-03T12:00:00Z',
+              y: -20,
+            },
+          ],
+        };
+        graphDefault.reflow(panData);
+        graphDefault.reflow(panData);
+        graphDefault.reflow(panData);
+        expect(graphDefault.config.axis.y.dataRange.isRangeModified).toEqual(false);
+      });
+    });
   });
 });

--- a/packages/carbon-graphs/tests/unit/controls/Line/LinePanning-spec.js
+++ b/packages/carbon-graphs/tests/unit/controls/Line/LinePanning-spec.js
@@ -430,66 +430,47 @@ describe('Line - Panning', () => {
       });
     });
     describe('when the same data is passed on multiple clicks of panning', () => {
-      it('Range modified should be false', () => {
-        const panData = {
-          key: 'uid_1',
-          values: [
-            {
-              x: '2016-03-03T12:00:00Z',
-              y: 0,
-            },
-            {
-              x: '2016-04-03T12:00:00Z',
-              y: 20,
-            },
-          ],
-        };
-        graphDefault.reflow(panData);
-        graphDefault.reflow(panData);
-        graphDefault.reflow(panData);
-        expect(graphDefault.config.axis.y.dataRange.isRangeModified).toEqual(false);
+      describe('when Minimum Datapoint is 0', () => {
+        it('Range modified should be false', () => {
+          const panData = {
+            key: 'uid_1',
+            values: [
+              {
+                x: '2016-03-03T12:00:00Z',
+                y: 0,
+              },
+              {
+                x: '2016-04-03T12:00:00Z',
+                y: 20,
+              },
+            ],
+          };
+          graphDefault.reflow(panData);
+          graphDefault.reflow(panData);
+          graphDefault.reflow(panData);
+          expect(graphDefault.config.axis.y.dataRange.isRangeModified).toEqual(false);
+        });
       });
-    });
-    describe('when the same data is passed on multiple clicks of panning and Minimum Data Range is 0', () => {
-      it('Range modified should be false', () => {
-        const panData = {
-          key: 'uid_1',
-          values: [
-            {
-              x: '2016-03-03T12:00:00Z',
-              y: 0,
-            },
-            {
-              x: '2016-04-03T12:00:00Z',
-              y: 20,
-            },
-          ],
-        };
-        graphDefault.reflow(panData);
-        graphDefault.reflow(panData);
-        graphDefault.reflow(panData);
-        expect(graphDefault.config.axis.y.dataRange.isRangeModified).toEqual(false);
-      });
-    });
-    describe('when the same data is passed on multiple clicks of panning and Maximum Data Range is 0', () => {
-      it('Range modified should be false', () => {
-        const panData = {
-          key: 'uid_1',
-          values: [
-            {
-              x: '2016-03-03T12:00:00Z',
-              y: 0,
-            },
-            {
-              x: '2016-04-03T12:00:00Z',
-              y: -20,
-            },
-          ],
-        };
-        graphDefault.reflow(panData);
-        graphDefault.reflow(panData);
-        graphDefault.reflow(panData);
-        expect(graphDefault.config.axis.y.dataRange.isRangeModified).toEqual(false);
+      describe('when Maximum Datapoint is 0', () => {
+        it('Range modified should be false', () => {
+          const panData = {
+            key: 'uid_1',
+            values: [
+              {
+                x: '2016-03-03T12:00:00Z',
+                y: 0,
+              },
+              {
+                x: '2016-04-03T12:00:00Z',
+                y: -20,
+              },
+            ],
+          };
+          graphDefault.reflow(panData);
+          graphDefault.reflow(panData);
+          graphDefault.reflow(panData);
+          expect(graphDefault.config.axis.y.dataRange.isRangeModified).toEqual(false);
+        });
       });
     });
   });

--- a/packages/carbon-graphs/webpack/dev-server.js
+++ b/packages/carbon-graphs/webpack/dev-server.js
@@ -1,5 +1,5 @@
-const WebpackDevServer = require('webpack-dev-server');
 const path = require('path');
+const WebpackDevServer = require('webpack-dev-server');
 const webpack = require('webpack');
 const { jsOptions, cssOptions } = require('./helpers/rules');
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,8 @@
+const path = require('path');
 const { merge } = require('webpack-merge');
 const {
   TerraDevSite,
 } = require('@cerner/terra-dev-site');
-const path = require('path');
 
 const WebpackConfigTerra = require('@cerner/webpack-config-terra');
 


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**
Fixed infinite padding in line graphs on multiple unload/load where maximum datapoint is zero.

Added a check for maximum datapoint to make sure isRangeModified is returned correctly when no data is changed. Previous behavior is, it always returns true when maximum datapoint is zero. 

**Why it was changed:**
When the maximum datapoint on an y axis is 0, padding is added on every loadContent, so that when multiple unloads and loads occur, the datapoints are "squished". (See example in linked investigation.)

The reason this is happening is that when the max value is 0, [isRangeModified always evaluates to true](https://github.com/cerner/terra-graphs/blob/main/packages/carbon-graphs/src/js/helpers/axis.js#L1596), thus on every load padding is re-added.
UXPLATFORM-7542 
UXPLATFORM-6895 



### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [x] Jest
- [x] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

Before the fix:

https://github.com/cerner/terra-graphs/assets/19804033/31ef9bb0-ae00-41d1-82e7-99ae25823919


After the fix:

https://github.com/cerner/terra-graphs/assets/19804033/8d63ff34-144c-4294-bb65-9eba73e6bbf7



### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-7542 

---

Thank you for contributing to Terra.
@cerner/terra
