### PR TITLE
Release September 20th, 2023

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-config-prettier": "^6.11.0",
     "eslint-config-standard": "^14.1.1",
     "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jsdoc": "^24.0.6",
+    "eslint-plugin-jsdoc": "^25.0.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-config-prettier": "^6.11.0",
     "eslint-config-standard": "^14.1.1",
     "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jsdoc": "^25.0.0",
+    "eslint-plugin-jsdoc": "25",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",

--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.23.2 - (September 20, 2023)
+
 * Fixed
   * Fixed transition reference error by adding the missing `d3-dispatch` dependency.
 

--- a/packages/carbon-graphs/package.json
+++ b/packages/carbon-graphs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cerner/carbon-graphs",
   "main": "lib/Graphs.js",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "description": "A graphing library built using d3 based on Cerner design standards",
   "repository": {
     "type": "git",
@@ -52,6 +52,7 @@
   "dependencies": {
     "d3-array": "1",
     "d3-axis": "1",
+    "d3-dispatch": "1",
     "d3-drag": "1",
     "d3-ease": "1",
     "d3-format": "1",
@@ -65,7 +66,6 @@
     "d3-time": "1",
     "d3-time-format": "2",
     "d3-timer": "1",
-    "d3-dispatch": "1",
     "d3-transition": "1.3.0"
   },
   "devDependencies": {

--- a/packages/terra-graphs-docs/CHANGELOG.md
+++ b/packages/terra-graphs-docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.5.0 - (September 20, 2023)
+
+* Changed
+  * Minor dependency version bump
+
 ## 1.4.1 - (August 21, 2023)
 
 * Added

--- a/packages/terra-graphs-docs/package.json
+++ b/packages/terra-graphs-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/terra-graphs-docs",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "A react based dev-site that has documentation and example graphs",
   "repository": {
     "type": "git",
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/cerner/terra-graphs#readme",
   "dependencies": {
-    "@cerner/carbon-graphs": "^2.23.1",
+    "@cerner/carbon-graphs": "^2.23.2",
     "classnames": "^2.2.5",
     "d3-selection": "1",
     "details-polyfill": "^1.2.0",


### PR DESCRIPTION
The following packages will be released:

  - @cerner/carbon-graphs@2.23.2
  - @cerner/terra-graphs-docs@1.5.0
  
eslint-plugin-jsdoc version bump was needed to resolve eslint conflicts that prevented `npm i` from working.
