### PR TITLE
Unlock d3-transition

### DIFF
--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Unlocked `d3-transition` and removed `d3-dispatch` dependency to fix transition reference error.
+
 ## 2.23.2 - (September 20, 2023)
 
 * Fixed

--- a/packages/carbon-graphs/package.json
+++ b/packages/carbon-graphs/package.json
@@ -52,7 +52,6 @@
   "dependencies": {
     "d3-array": "1",
     "d3-axis": "1",
-    "d3-dispatch": "1",
     "d3-drag": "1",
     "d3-ease": "1",
     "d3-format": "1",
@@ -66,7 +65,7 @@
     "d3-time": "1",
     "d3-time-format": "2",
     "d3-timer": "1",
-    "d3-transition": "1.3.0"
+    "d3-transition": "1"
   },
   "devDependencies": {
     "@cerner/carbon-site-helpers": "^1.11.3",


### PR DESCRIPTION
### Summary
Currently Clinical Detail view doesn't work due to transition error coming from d3.transition package.
<img width="1880" alt="Screenshot 2023-09-25 at 2 55 49 PM" src="https://github.com/cerner/terra-graphs/assets/119358186/7708a23c-3468-4908-bfc3-fd457c0d789c">
The d3.transition version was unlocked to pull the latest change that doesn't have that error.

### Testing

#### Testing changes in Terra-Clinical for Clinical Detail view
Carbon-graphs package with changes was created locally and terra-clinical pulled from that local package. **Note: for change to work with terra-clinical, carbon-graphs might need to be moved from dev dependencies to dependencies.**
<img width="1383" alt="Screenshot 2023-09-25 at 4 39 05 PM" src="https://github.com/cerner/terra-graphs/assets/119358186/2aa25a10-d677-4f4e-ba0a-44bcf9c9c611">

It resolved the isuue and Clinical Detail view had no issues:
<img width="1878" alt="Screenshot 2023-09-25 at 3 04 54 PM" src="https://github.com/cerner/terra-graphs/assets/119358186/81ce3096-4ad3-429f-961b-7055d44fcdd9">

#### Testing changes in Terra-Graphs
Tested changes locally for no issues with existing functionality:
<img width="1881" alt="Screenshot 2023-09-25 at 2 48 09 PM" src="https://github.com/cerner/terra-graphs/assets/119358186/408f5fe2-c10a-481d-aa50-8f737fcf90f5">
<img width="1883" alt="Screenshot 2023-09-25 at 2 48 21 PM" src="https://github.com/cerner/terra-graphs/assets/119358186/2af5a790-aedc-4ae4-b5db-f719d95da75d">
<img width="1879" alt="Screenshot 2023-09-25 at 2 48 35 PM" src="https://github.com/cerner/terra-graphs/assets/119358186/4ed94873-b4ba-4eaa-8c6f-6e6f07220c36">


This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [x] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

