### PR TITLE
Release September 26th, 2023

### DIFF
--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.23.3 - (September 25, 2023)
+
 * Fixed
   * Unlocked `d3-transition` and removed `d3-dispatch` dependency to fix transition reference error.
 

--- a/packages/carbon-graphs/package.json
+++ b/packages/carbon-graphs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cerner/carbon-graphs",
   "main": "lib/Graphs.js",
-  "version": "2.23.2",
+  "version": "2.23.3",
   "description": "A graphing library built using d3 based on Cerner design standards",
   "repository": {
     "type": "git",

--- a/packages/terra-graphs-docs/CHANGELOG.md
+++ b/packages/terra-graphs-docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.6.0 - (September 25, 2023)
+
+* Changed
+  * Minor dependency version bump
+
 ## 1.5.0 - (September 20, 2023)
 
 * Changed

--- a/packages/terra-graphs-docs/package.json
+++ b/packages/terra-graphs-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/terra-graphs-docs",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "A react based dev-site that has documentation and example graphs",
   "repository": {
     "type": "git",
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/cerner/terra-graphs#readme",
   "dependencies": {
-    "@cerner/carbon-graphs": "^2.23.2",
+    "@cerner/carbon-graphs": "^2.23.3",
     "classnames": "^2.2.5",
     "d3-selection": "1",
     "details-polyfill": "^1.2.0",


### PR DESCRIPTION
The following packages will be released:

  - @cerner/carbon-graphs@2.23.3
  - @cerner/terra-graphs-docs@1.6.0
