### PR TITLE
release April 19th, 2024

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42061,7 +42061,7 @@
     },
     "packages/carbon-graphs": {
       "name": "@cerner/carbon-graphs",
-      "version": "2.25.0",
+      "version": "2.26.0",
       "license": "Apache-2.0",
       "dependencies": {
         "d3-array": "1",
@@ -42159,10 +42159,10 @@
     },
     "packages/terra-graphs-docs": {
       "name": "@cerner/terra-graphs-docs",
-      "version": "1.9.3",
+      "version": "1.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cerner/carbon-graphs": "^2.25.0",
+        "@cerner/carbon-graphs": "^2.26.0",
         "classnames": "2",
         "d3-selection": "1",
         "details-polyfill": "1",

--- a/packages/carbon-graphs/CHANGELOG.md
+++ b/packages/carbon-graphs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 2.26.0 - (April 19, 2024)
+
+* Changed
+  * Minor dependency version bump.
+
 ## 2.25.0 - (April 5, 2024)
 
 * Added

--- a/packages/carbon-graphs/package.json
+++ b/packages/carbon-graphs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/carbon-graphs",
-  "version": "2.25.0",
+  "version": "2.26.0",
   "description": "A graphing library built using d3 based on Cerner design standards",
   "author": "Cerner Corporation",
   "repository": {

--- a/packages/terra-graphs-docs/CHANGELOG.md
+++ b/packages/terra-graphs-docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.10.0 - (April 19, 2024)
+
 * Added
   * Added new _Reflow_ documentation page and reflow examples.
 

--- a/packages/terra-graphs-docs/package.json
+++ b/packages/terra-graphs-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/terra-graphs-docs",
-  "version": "1.9.3",
+  "version": "1.10.0",
   "description": "A react based dev-site that has documentation and example graphs",
   "author": "Cerner Corporation",
   "repository": {
@@ -36,7 +36,7 @@
     "NOTICE"
   ],
   "dependencies": {
-    "@cerner/carbon-graphs": "^2.25.0",
+    "@cerner/carbon-graphs": "^2.26.0",
     "classnames": "2",
     "d3-selection": "1",
     "details-polyfill": "1",


### PR DESCRIPTION
The following packages will be released:

  - @cerner/carbon-graphs@2.26.0
  - @cerner/terra-graphs-docs@1.10.0

